### PR TITLE
Added capability to customize page-size (fixes FrameTooLongException)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>datastax.astra.migrate</groupId>
   <artifactId>cassandra-data-migrator</artifactId>
-  <version>2.7</version>
+  <version>2.8</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/datastax/astra/migrate/BaseJobSession.java
+++ b/src/main/java/datastax/astra/migrate/BaseJobSession.java
@@ -33,6 +33,7 @@ public abstract class BaseJobSession {
     protected List<Integer> updateSelectMapping = new ArrayList<Integer>();
 
     protected Integer batchSize = 1;
+    protected Integer fetchSizeInRows = 1000;
     protected Integer printStatsAfter = 100000;
 
     protected Boolean writeTimeStampFilter = Boolean.FALSE;
@@ -67,6 +68,7 @@ public abstract class BaseJobSession {
 
         return key.toString();
     }
+
     public List<MigrateDataType> getTypes(String types) {
         List<MigrateDataType> dataTypes = new ArrayList<MigrateDataType>();
         for (String type : types.split(",")) {

--- a/src/main/scala/datastax/astra/migrate/AbstractJob.scala
+++ b/src/main/scala/datastax/astra/migrate/AbstractJob.scala
@@ -10,13 +10,13 @@ class AbstractJob extends BaseJob {
   abstractLogger.info("PARAM -- Split Size: " + splitSize)
   abstractLogger.info("PARAM -- Coverage Percent: " + coveragePercent)
 
-  var sourceConnection = getConnection(true, sourceIsAstra, sourceScbPath, sourceHost, sourceUsername, sourcePassword, sourceReadConsistencyLevel,
+  var sourceConnection = getConnection(true, sourceIsAstra, sourceScbPath, sourceHost, sourceUsername, sourcePassword,
     sourceTrustStorePath, sourceTrustStorePassword, sourceTrustStoreType, sourceKeyStorePath, sourceKeyStorePassword, sourceEnabledAlgorithms);
 
-  var destinationConnection = getConnection(false, destinationIsAstra, destinationScbPath, destinationHost, destinationUsername, destinationPassword, destinationReadConsistencyLevel,
+  var destinationConnection = getConnection(false, destinationIsAstra, destinationScbPath, destinationHost, destinationUsername, destinationPassword,
     destinationTrustStorePath, destinationTrustStorePassword, destinationTrustStoreType, destinationKeyStorePath, destinationKeyStorePassword, destinationEnabledAlgorithms);
 
-  private def getConnection(isSource: Boolean, isAstra: String, scbPath: String, host: String, username: String, password: String, readConsistencyLevel: String,
+  private def getConnection(isSource: Boolean, isAstra: String, scbPath: String, host: String, username: String, password: String,
                             trustStorePath: String, trustStorePassword: String, trustStoreType: String,
                             keyStorePath: String, keyStorePassword: String, enabledAlgorithms: String): CassandraConnector = {
     var connType: String = "Source"
@@ -31,7 +31,7 @@ class AbstractJob extends BaseJob {
       return CassandraConnector(config
         .set("spark.cassandra.auth.username", username)
         .set("spark.cassandra.auth.password", password)
-        .set("spark.cassandra.input.consistency.level", readConsistencyLevel)
+        .set("spark.cassandra.input.consistency.level", consistencyLevel)
         .set("spark.cassandra.connection.config.cloud.path", scbPath))
     } else if (null != trustStorePath && !trustStorePath.trim.isEmpty) {
       abstractLogger.info(connType + ": Connecting to Cassandra (or DSE) with SSL host: " + host);
@@ -45,7 +45,7 @@ class AbstractJob extends BaseJob {
       return CassandraConnector(config
         .set("spark.cassandra.auth.username", username)
         .set("spark.cassandra.auth.password", password)
-        .set("spark.cassandra.input.consistency.level", readConsistencyLevel)
+        .set("spark.cassandra.input.consistency.level", consistencyLevel)
         .set("spark.cassandra.connection.host", host)
         .set("spark.cassandra.connection.ssl.enabled", "true")
         .set("spark.cassandra.connection.ssl.enabledAlgorithms", enabledAlgorithmsVar)
@@ -61,7 +61,7 @@ class AbstractJob extends BaseJob {
 
       return CassandraConnector(config.set("spark.cassandra.auth.username", username)
         .set("spark.cassandra.auth.password", password)
-        .set("spark.cassandra.input.consistency.level", readConsistencyLevel)
+        .set("spark.cassandra.input.consistency.level", consistencyLevel)
         .set("spark.cassandra.connection.host", host))
     }
 

--- a/src/main/scala/datastax/astra/migrate/BaseJob.scala
+++ b/src/main/scala/datastax/astra/migrate/BaseJob.scala
@@ -18,12 +18,13 @@ class BaseJob extends App {
   val sContext = spark.sparkContext
   val sc = sContext.getConf
 
+  val consistencyLevel = Util.getSparkPropOr(sc, "spark.read.consistency.level", "LOCAL_QUORUM")
+
   val sourceIsAstra = Util.getSparkPropOr(sc, "spark.origin.isAstra", "false")
   val sourceScbPath = Util.getSparkPropOrEmpty(sc, "spark.origin.scb")
   val sourceHost = Util.getSparkPropOrEmpty(sc, "spark.origin.host")
   val sourceUsername = Util.getSparkPropOrEmpty(sc, "spark.origin.username")
   val sourcePassword = Util.getSparkPropOrEmpty(sc, "spark.origin.password")
-  val sourceReadConsistencyLevel = Util.getSparkPropOr(sc, "spark.origin.read.consistency.level", "LOCAL_QUORUM")
   val sourceTrustStorePath = Util.getSparkPropOrEmpty(sc, "spark.origin.trustStore.path")
   val sourceTrustStorePassword = Util.getSparkPropOrEmpty(sc, "spark.origin.trustStore.password")
   val sourceTrustStoreType = Util.getSparkPropOr(sc, "spark.origin.trustStore.type", "JKS")
@@ -36,7 +37,6 @@ class BaseJob extends App {
   val destinationHost = Util.getSparkPropOrEmpty(sc, "spark.target.host")
   val destinationUsername = Util.getSparkProp(sc, "spark.target.username")
   val destinationPassword = Util.getSparkProp(sc, "spark.target.password")
-  val destinationReadConsistencyLevel = Util.getSparkPropOr(sc, "spark.target.read.consistency.level", "LOCAL_QUORUM")
   val destinationTrustStorePath = Util.getSparkPropOrEmpty(sc, "spark.target.trustStore.path")
   val destinationTrustStorePassword = Util.getSparkPropOrEmpty(sc, "spark.target.trustStore.password")
   val destinationTrustStoreType = Util.getSparkPropOr(sc, "spark.target.trustStore.type", "JKS")
@@ -48,7 +48,7 @@ class BaseJob extends App {
   val maxPartition = new BigInteger(Util.getSparkPropOr(sc, "spark.origin.maxPartition", "9223372036854775807"))
   val coveragePercent = Util.getSparkPropOr(sc, "spark.coveragePercent", "100")
   val splitSize = Integer.parseInt(Util.getSparkPropOr(sc, "spark.splitSize", "10000"))
-  
+
   protected def exitSpark() = {
     spark.stop()
     abstractLogger.info("################################################################################################")

--- a/src/main/scala/datastax/astra/migrate/OriginData.scala
+++ b/src/main/scala/datastax/astra/migrate/OriginData.scala
@@ -9,13 +9,13 @@ object OriginData extends BaseJob {
 
   val logger = LoggerFactory.getLogger(this.getClass.getName)
   logger.info("Started Migration App")
-  var sourceConnection = getConnection(true, sourceIsAstra, sourceScbPath, sourceHost, sourceUsername, sourcePassword, sourceReadConsistencyLevel,
+  var sourceConnection = getConnection(true, sourceIsAstra, sourceScbPath, sourceHost, sourceUsername, sourcePassword,
     sourceTrustStorePath, sourceTrustStorePassword, sourceTrustStoreType, sourceKeyStorePath, sourceKeyStorePassword, sourceEnabledAlgorithms);
   analyzeSourceTable(sourceConnection)
   exitSpark
 
 
-  private def getConnection(isSource: Boolean, isAstra: String, scbPath: String, host: String, username: String, password: String, readConsistencyLevel: String,
+  private def getConnection(isSource: Boolean, isAstra: String, scbPath: String, host: String, username: String, password: String,
                             trustStorePath: String, trustStorePassword: String, trustStoreType: String,
                             keyStorePath: String, keyStorePassword: String, enabledAlgorithms: String): CassandraConnector = {
     var connType: String = "Source"
@@ -26,7 +26,7 @@ object OriginData extends BaseJob {
       return CassandraConnector(sc
         .set("spark.cassandra.auth.username", username)
         .set("spark.cassandra.auth.password", password)
-        .set("spark.cassandra.input.consistency.level", readConsistencyLevel)
+        .set("spark.cassandra.input.consistency.level", consistencyLevel)
         .set("spark.cassandra.connection.config.cloud.path", scbPath))
     } else if (null != trustStorePath && !trustStorePath.trim.isEmpty) {
       abstractLogger.info(connType + ": Connected to Cassandra (or DSE) with SSL!");
@@ -40,7 +40,7 @@ object OriginData extends BaseJob {
       return CassandraConnector(sc
         .set("spark.cassandra.auth.username", username)
         .set("spark.cassandra.auth.password", password)
-        .set("spark.cassandra.input.consistency.level", readConsistencyLevel)
+        .set("spark.cassandra.input.consistency.level", consistencyLevel)
         .set("spark.cassandra.connection.host", host)
         .set("spark.cassandra.connection.ssl.enabled", "true")
         .set("spark.cassandra.connection.ssl.enabledAlgorithms", enabledAlgorithmsVar)
@@ -56,7 +56,7 @@ object OriginData extends BaseJob {
 
       return CassandraConnector(sc.set("spark.cassandra.auth.username", username)
         .set("spark.cassandra.auth.password", password)
-        .set("spark.cassandra.input.consistency.level", readConsistencyLevel)
+        .set("spark.cassandra.input.consistency.level", consistencyLevel)
         .set("spark.cassandra.connection.host", host))
     }
 
@@ -77,7 +77,4 @@ object OriginData extends BaseJob {
   }
 
 }
-
-
-
 

--- a/src/resources/sparkConf.properties
+++ b/src/resources/sparkConf.properties
@@ -2,27 +2,21 @@ spark.origin.isAstra                              false
 spark.origin.host                                 localhost
 spark.origin.username                             some-username
 spark.origin.password                             some-secret-password
-spark.origin.read.consistency.level               LOCAL_QUORUM
 spark.origin.keyspaceTable                        test.a1
 
 spark.target.isAstra                              true
 spark.target.scb                                  file:///aaa/bbb/secure-connect-enterprise.zip
 spark.target.username                             client-id
 spark.target.password                             client-secret
-spark.target.read.consistency.level               LOCAL_QUORUM
 spark.target.keyspaceTable                        test.a2
 spark.target.autocorrect.missing                  false
 spark.target.autocorrect.mismatch                 false
-spark.target.custom.writeTime                     0
 
 spark.maxRetries                                  10
 spark.readRateLimit                               20000
 spark.writeRateLimit                              20000
 spark.splitSize                                   10000
 spark.batchSize                                   5
-spark.coveragePercent                             100
-spark.printStatsAfter                             100000
-spark.fieldGuardraillimitMB                       10
 
 spark.query.origin                                partition-key,clustering-key,order-date,amount
 spark.query.origin.partitionKey                   partition-key
@@ -39,6 +33,14 @@ spark.counterTable.cql.index                      0
 spark.origin.writeTimeStampFilter                 false
 spark.origin.minWriteTimeStampFilter              0
 spark.origin.maxWriteTimeStampFilter              9223372036854775807
+
+########################## ONLY CHANGE IF YOU KNOW WHAT YOU ARE DOING ###############################
+#spark.coveragePercent                             100
+#spark.printStatsAfter                             100000
+#spark.read.consistency.level                      LOCAL_QUORUM
+#spark.read.fetch.sizeInRows                       1000
+#spark.target.custom.writeTime                     0
+#spark.fieldGuardraillimitMB                       10
 
 ################### ONLY USE if needing to get record count of recs greater than 10MB from Origin ######################
 #spark.origin.checkTableforColSize                 false


### PR DESCRIPTION
Added capability to customize `fetch-size` (fixes `FrameTooLongException`)
Use the `spark.read.fetch.sizeInRows` property to applicable value, default is `1000` 