### PR TITLE
Use applicable read/write consistency from properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>datastax.astra.migrate</groupId>
   <artifactId>cassandra-data-migrator</artifactId>
-  <version>2.10.1</version>
+  <version>2.11.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/datastax/astra/migrate/AbstractJobSession.java
+++ b/src/main/java/datastax/astra/migrate/AbstractJobSession.java
@@ -24,6 +24,7 @@ public class AbstractJobSession extends BaseJobSession {
     }
 
     protected AbstractJobSession(CqlSession sourceSession, CqlSession astraSession, SparkConf sc, boolean isJobMigrateRowsFromFile) {
+        super(sc);
         this.sourceSession = sourceSession;
         this.astraSession = astraSession;
 
@@ -79,6 +80,8 @@ public class AbstractJobSession extends BaseJobSession {
             customWritetime = Long.parseLong(customWriteTimeStr);
         }
 
+        logger.info("PARAM -- Read Consistency: {}", readConsistencyLevel);
+        logger.info("PARAM -- Write Consistency: {}", writeConsistencyLevel);
         logger.info("PARAM -- Write Batch Size: {}", batchSize);
         logger.info("PARAM -- Read Fetch Size: {}", fetchSizeInRows);
         logger.info("PARAM -- Source Keyspace Table: {}", sourceKeyspaceTable);
@@ -98,6 +101,9 @@ public class AbstractJobSession extends BaseJobSession {
         String selectCols = Util.getSparkProp(sc, "spark.query.origin");
         String partionKey = Util.getSparkProp(sc, "spark.query.origin.partitionKey");
         String sourceSelectCondition = Util.getSparkPropOrEmpty(sc, "spark.query.condition");
+        if (!sourceSelectCondition.isEmpty() && !sourceSelectCondition.trim().toUpperCase().startsWith("AND")) {
+            sourceSelectCondition = " AND " + sourceSelectCondition;
+        }
 
         final StringBuilder selectTTLWriteTimeCols = new StringBuilder();
         String[] allCols = selectCols.split(",");
@@ -172,7 +178,7 @@ public class AbstractJobSession extends BaseJobSession {
     }
 
     public BoundStatement bindInsert(PreparedStatement insertStatement, Row sourceRow, Row astraRow) {
-        BoundStatement boundInsertStatement = insertStatement.bind();
+        BoundStatement boundInsertStatement = insertStatement.bind().setConsistencyLevel(writeConsistencyLevel);
 
         if (isCounterTable) {
             for (int index = 0; index < selectColTypes.size(); index++) {
@@ -232,7 +238,7 @@ public class AbstractJobSession extends BaseJobSession {
     }
 
     public BoundStatement selectFromAstra(PreparedStatement selectStatement, Row sourceRow) {
-        BoundStatement boundSelectStatement = selectStatement.bind();
+        BoundStatement boundSelectStatement = selectStatement.bind().setConsistencyLevel(readConsistencyLevel);
         for (int index = 0; index < idColTypes.size(); index++) {
             MigrateDataType dataType = idColTypes.get(index);
             boundSelectStatement = boundSelectStatement.set(index, getData(dataType, index, sourceRow),

--- a/src/main/java/datastax/astra/migrate/BaseJobSession.java
+++ b/src/main/java/datastax/astra/migrate/BaseJobSession.java
@@ -1,9 +1,11 @@
 package datastax.astra.migrate;
 
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.RateLimiter;
+import org.apache.spark.SparkConf;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +17,8 @@ public abstract class BaseJobSession {
     protected PreparedStatement sourceSelectStatement;
     protected PreparedStatement astraSelectStatement;
     protected PreparedStatement astraInsertStatement;
+    protected ConsistencyLevel readConsistencyLevel;
+    protected ConsistencyLevel writeConsistencyLevel;
 
     // Read/Write Rate limiter
     // Determine the total throughput for the entire cluster in terms of wries/sec,
@@ -54,6 +58,11 @@ public abstract class BaseJobSession {
     protected String filterColType;
     protected Integer filterColIndex;
     protected String filterColValue;
+
+    protected BaseJobSession(SparkConf sc) {
+        readConsistencyLevel = Util.mapToConsistencyLevel(Util.getSparkPropOrEmpty(sc, "spark.consistency.read"));
+        writeConsistencyLevel = Util.mapToConsistencyLevel(Util.getSparkPropOrEmpty(sc, "spark.consistency.write"));
+    }
 
     public String getKey(Row sourceRow) {
         StringBuffer key = new StringBuffer();

--- a/src/main/java/datastax/astra/migrate/CopyJobSession.java
+++ b/src/main/java/datastax/astra/migrate/CopyJobSession.java
@@ -47,8 +47,10 @@ public class CopyJobSession extends AbstractJobSession {
         for (int retryCount = 1; retryCount <= maxAttempts; retryCount++) {
 
             try {
-                ResultSet resultSet = sourceSession.execute(sourceSelectStatement.bind(hasRandomPartitioner ? min : min.longValueExact(),
-                        hasRandomPartitioner ? max : max.longValueExact()).setPageSize(fetchSizeInRows));
+                ResultSet resultSet = sourceSession.execute(sourceSelectStatement.bind(hasRandomPartitioner ?
+                                min : min.longValueExact(), hasRandomPartitioner ? max : max.longValueExact())
+                        .setConsistencyLevel(readConsistencyLevel).setPageSize(fetchSizeInRows));
+
                 Collection<CompletionStage<AsyncResultSet>> writeResults = new ArrayList<CompletionStage<AsyncResultSet>>();
 
                 // cannot do batching if the writeFilter is greater than 0 or

--- a/src/main/java/datastax/astra/migrate/CopyPKJobSession.java
+++ b/src/main/java/datastax/astra/migrate/CopyPKJobSession.java
@@ -43,7 +43,7 @@ public class CopyPKJobSession extends AbstractJobSession {
                 readCounter.incrementAndGet();
                 String[] pkFields = row.split(" %% ");
                 int idx = 0;
-                BoundStatement bspk = sourceSelectStatement.bind();
+                BoundStatement bspk = sourceSelectStatement.bind().setConsistencyLevel(readConsistencyLevel);
                 for (MigrateDataType tp : idColTypes) {
                     bspk = bspk.set(idx, convert(tp.typeClass, pkFields[idx]), tp.typeClass);
                     idx++;

--- a/src/main/java/datastax/astra/migrate/DiffJobSession.java
+++ b/src/main/java/datastax/astra/migrate/DiffJobSession.java
@@ -1,6 +1,5 @@
 package datastax.astra.migrate;
 
-import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
@@ -61,9 +60,9 @@ public class DiffJobSession extends CopyJobSession {
 
             try {
                 // cannot do batching if the writeFilter is greater than 0
-                ResultSet resultSet = sourceSession.execute(
-                        sourceSelectStatement.bind(hasRandomPartitioner ? min : min.longValueExact(), hasRandomPartitioner ? max : max.longValueExact())
-                                .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM).setPageSize(fetchSizeInRows));
+                ResultSet resultSet = sourceSession.execute(sourceSelectStatement.bind(hasRandomPartitioner ?
+                                min : min.longValueExact(), hasRandomPartitioner ? max : max.longValueExact())
+                        .setConsistencyLevel(readConsistencyLevel).setPageSize(fetchSizeInRows));
 
                 Map<Row, CompletionStage<AsyncResultSet>> srcToTargetRowMap = new HashMap<Row, CompletionStage<AsyncResultSet>>();
                 StreamSupport.stream(resultSet.spliterator(), false).forEach(srcRow -> {

--- a/src/main/java/datastax/astra/migrate/Util.java
+++ b/src/main/java/datastax/astra/migrate/Util.java
@@ -1,10 +1,12 @@
 package datastax.astra.migrate;
 
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import org.apache.spark.SparkConf;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 public class Util {
@@ -37,6 +39,46 @@ public class Util {
         } catch (FileNotFoundException fnfe) {
             throw new RuntimeException("No '" + fileName + "' file found!! Add this file in the current folder & rerun!");
         }
+    }
+
+    public static ConsistencyLevel mapToConsistencyLevel(String level) {
+        ConsistencyLevel retVal = ConsistencyLevel.LOCAL_QUORUM;
+        if (null != level) {
+            switch (level.toUpperCase(Locale.ROOT)) {
+                case "ANY":
+                    retVal = ConsistencyLevel.ANY;
+                    break;
+                case "ONE":
+                    retVal = ConsistencyLevel.ONE;
+                    break;
+                case "TWO":
+                    retVal = ConsistencyLevel.TWO;
+                    break;
+                case "THREE":
+                    retVal = ConsistencyLevel.THREE;
+                    break;
+                case "QUORUM":
+                    retVal = ConsistencyLevel.QUORUM;
+                    break;
+                case "LOCAL_ONE":
+                    retVal = ConsistencyLevel.LOCAL_ONE;
+                    break;
+                case "EACH_QUORUM":
+                    retVal = ConsistencyLevel.EACH_QUORUM;
+                    break;
+                case "SERIAL":
+                    retVal = ConsistencyLevel.SERIAL;
+                    break;
+                case "LOCAL_SERIAL":
+                    retVal = ConsistencyLevel.LOCAL_SERIAL;
+                    break;
+                case "ALL":
+                    retVal = ConsistencyLevel.ALL;
+                    break;
+            }
+        }
+
+        return retVal;
     }
 
 }

--- a/src/main/java/datastax/astra/migrate/Util.java
+++ b/src/main/java/datastax/astra/migrate/Util.java
@@ -1,12 +1,12 @@
 package datastax.astra.migrate;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import org.apache.commons.lang.StringUtils;
 import org.apache.spark.SparkConf;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.util.Locale;
 import java.util.NoSuchElementException;
 
 public class Util {
@@ -43,8 +43,8 @@ public class Util {
 
     public static ConsistencyLevel mapToConsistencyLevel(String level) {
         ConsistencyLevel retVal = ConsistencyLevel.LOCAL_QUORUM;
-        if (null != level) {
-            switch (level.toUpperCase(Locale.ROOT)) {
+        if (StringUtils.isNotEmpty(level)) {
+            switch (level.toUpperCase()) {
                 case "ANY":
                     retVal = ConsistencyLevel.ANY;
                     break;

--- a/src/resources/sparkConf.properties
+++ b/src/resources/sparkConf.properties
@@ -18,13 +18,24 @@ spark.batchSize                                   5
 
 spark.query.origin                                partition-key,clustering-key,order-date,amount
 spark.query.origin.partitionKey                   partition-key
-spark.query.target                                partition-key,clustering-key,order-date,amount
 spark.query.target.id                             partition-key,clustering-key
 spark.query.types                                 9,1,4,3
 spark.query.ttl.cols                              2,3
 spark.query.writetime.cols                        2,3
 
-################################## ENABLE ONLY IF IT IS A COUNTER TABLE #####################################
+##### ENABLE ONLY IF COLUMN NAMES ON TARGET IS DIFFERENT FROM ORIGIN (SCHEMA & DATA-TYPES MUST BE SAME) #####
+#spark.query.target                                partition-key,clustering-key,order-date,amount
+
+################# ENABLE ONLY IF YOU WANT TO MIGRATE/VALIDATE SOME DATA BASED ON CQL FILTER #################
+#spark.query.condition
+
+################# ENABLE ONLY IF YOU WANT TO MIGRATE/VALIDATE SOME % (NOT 100%) DATA   ######################
+#spark.coveragePercent                             10
+
+#################### ENABLE ONLY IF WANT LOG STATS MORE OR LESS FREQUENTLY THAN DEFAULT #####################
+#spark.printStatsAfter                             100000
+
+################################# ENABLE ONLY IF IT IS A COUNTER TABLE ######################################
 #spark.counterTable                                false
 #spark.counterTable.cql
 #spark.counterTable.cql.index                      0
@@ -34,12 +45,17 @@ spark.query.writetime.cols                        2,3
 #spark.origin.minWriteTimeStampFilter              0
 #spark.origin.maxWriteTimeStampFilter              4102444800000000
 
-############################### ONLY CHANGE IF YOU KNOW WHAT YOU ARE DOING ##################################
-#spark.coveragePercent                             100
-#spark.printStatsAfter                             100000
-#spark.read.consistency.level                      LOCAL_QUORUM
+######## ENABLE ONLY IF YOU WANT TO USE READ AND/OR WRITE CONSISTENCY OTHER THAN LOCAL_QUORUM  ##############
+#spark.consistency.read                            LOCAL_QUORUM
+#spark.consistency.write                           LOCAL_QUORUM
+
+############# ENABLE ONLY IF YOU WANT TO REDUCE FETCH-SIZE TO AVOID FrameTooLongException  ##################
 #spark.read.fetch.sizeInRows                       1000
+
+############### ENABLE ONLY IF YOU WANT TO USE CUSTOM FIXED WRITETIME VALUE ON TARGET  ######################
 #spark.target.custom.writeTime                     0
+
+#################### ONLY USE if SKIPPING recs greater than 10MB from Origin needed #########################
 #spark.fieldGuardraillimitMB                       10
 
 #################### ONLY USE if count of recs greater than 10MB from Origin needed #########################
@@ -97,9 +113,5 @@ spark.query.writetime.cols                        2,3
 # "spark.query.writetime.cols" - Comma separated column indexes from "spark.query.origin" used to find largest writetime.
 #  Note: The tool migrates TTL & Writetimes at row-level and not field-level.
 #        Migration will use the largest TTL & Writetimes value per row.
-#
-# "spark.target.custom.writeTime" - User specified writetime. When set, this static value will be used as target writetime.
-#
-# Default value for "spark.origin.maxWriteTimeStampFilter" is "9223372036854775807" (max long value)
 #
 #############################################################################################################


### PR DESCRIPTION
- Use applicable consistency from properties (bug-fix)
- Allow separate read & write consistency (enhancement)
- Added notes/docs to properties file (docs)
- `spark.query.condition` should not require `AND` at start of condition (enhancement)