### PR TITLE
Fixed incorrect count issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>datastax.astra.migrate</groupId>
   <artifactId>cassandra-data-migrator</artifactId>
-  <version>2.11.0</version>
+  <version>2.11.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/resources/sparkConf.properties
+++ b/src/resources/sparkConf.properties
@@ -10,7 +10,7 @@ spark.target.keyspaceTable                        test.a2
 spark.target.autocorrect.missing                  false
 spark.target.autocorrect.mismatch                 false
 
-spark.maxRetries                                  5
+spark.maxRetries                                  3
 spark.readRateLimit                               20000
 spark.writeRateLimit                              20000
 spark.splitSize                                   10000


### PR DESCRIPTION
Fixed incorrect count issue caused when retries happen due to an error. Fixes #57 
Also included error-count to report possible partition-ranges that could not be moved.