### PR TITLE
CDM-13 : properties now retrieved via helpers rather than SparkConf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <scalatest.version>3.2.12</scalatest.version>
     <connector.version>3.2.0</connector.version>
     <cassandra.version>3.11.13</cassandra.version>
-    <junit.version>4.13.2</junit.version>
+    <junit.version>5.9.1</junit.version>
   </properties>
 
   <distributionManagement>
@@ -40,6 +40,10 @@
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -98,8 +102,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
@@ -175,9 +179,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
       </plugin>
       <!-- enable scalatest -->
       <plugin>

--- a/src/main/java/datastax/astra/migrate/MigrateDataType.java
+++ b/src/main/java/datastax/astra/migrate/MigrateDataType.java
@@ -13,23 +13,52 @@ import java.util.*;
 
 public class MigrateDataType {
     Class typeClass = Object.class;
+    String dataTypeString = "";
+    int type = -1;
     List<Class> subTypes = new ArrayList<Class>();
+    private boolean isValid = false;
+    private static int minType = 0;
+    private static int maxType = 19;
 
     public MigrateDataType(String dataType) {
+        dataTypeString = dataType;
         if (dataType.contains("%")) {
             int count = 1;
             for (String type : dataType.split("%")) {
+                int typeAsInt = typeAsInt(type);
                 if (count == 1) {
-                    typeClass = getType(Integer.parseInt(type));
+                    this.type = typeAsInt;
                 } else {
-                    subTypes.add(getType(Integer.parseInt(type)));
+                    subTypes.add(getType(typeAsInt));
                 }
                 count++;
             }
         } else {
-            int type = Integer.parseInt(dataType);
-            typeClass = getType(type);
+            this.type = typeAsInt(dataType);
         }
+        this.typeClass = getType(this.type);
+
+        if (this.type >= minType && this.type <= maxType) {
+            isValid = true;
+            for (Object o : subTypes) {
+                if (null == o || Object.class == o) {
+                    isValid = false;
+                }
+            }
+        }
+        else {
+            isValid = false;
+        }
+    }
+
+    private int typeAsInt(String dataType) {
+        int rtn = -1;
+        try {
+            rtn = Integer.parseInt(dataType);
+        } catch (NumberFormatException e) {
+            rtn = -1;
+        }
+        return rtn;
     }
 
     public boolean diff(Object source, Object astra) {
@@ -91,4 +120,25 @@ public class MigrateDataType {
         return Object.class;
     }
 
+    public Class getType() {
+        return this.typeClass;
+    }
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MigrateDataType that = (MigrateDataType) o;
+        return type == that.type &&
+                Objects.equals(subTypes, that.subTypes);
+    }
+
+    @Override
+    public String toString() {
+        return dataTypeString;
+    }
 }

--- a/src/main/java/datastax/astra/migrate/properties/KnownProperties.java
+++ b/src/main/java/datastax/astra/migrate/properties/KnownProperties.java
@@ -1,0 +1,428 @@
+package datastax.astra.migrate.properties;
+
+import datastax.astra.migrate.MigrateDataType;
+
+import java.util.*;
+
+public class KnownProperties {
+
+    public enum PropertyType {
+        STRING,
+        NUMBER,
+        BOOLEAN,
+        STRING_LIST,
+        NUMBER_LIST,
+        MIGRATION_TYPE,
+        MIGRATION_TYPE_LIST,
+        TEST_UNHANDLED_TYPE
+    }
+
+    private static Map<String,PropertyType> types = new HashMap<>();
+    private static Map<String,String> defaults = new HashMap<>();
+    private static Set<String> required = new HashSet<>();
+
+    //==========================================================================
+    // Properties to establish connections to the origin and target databases
+    //==========================================================================
+    public static final String ORIGIN_CONNECT_HOST           = "spark.origin.host";          // localhost
+    public static final String ORIGIN_CONNECT_PORT           = "spark.origin.port";          // 9042
+    public static final String ORIGIN_CONNECT_SCB            = "spark.origin.scb";           // file:///aaa/bbb/secure-connect-enterprise.zip
+    public static final String ORIGIN_CONNECT_USERNAME       = "spark.origin.username";      // some-username
+    public static final String ORIGIN_CONNECT_PASSWORD       = "spark.origin.password";      // some-secret-password
+    public static final String TARGET_CONNECT_HOST           = "spark.target.host";          // localhost
+    public static final String TARGET_CONNECT_PORT           = "spark.target.port";          // 9042
+    public static final String TARGET_CONNECT_SCB            = "spark.target.scb";           // file:///aaa/bbb/secure-connect-enterprise.zip
+    public static final String TARGET_CONNECT_USERNAME       = "spark.target.username";      // some-username
+    public static final String TARGET_CONNECT_PASSWORD       = "spark.target.password";      // some-secret-password
+
+    public static final String READ_CL                       = "spark.consistency.read";     // LOCAL_QUORUM
+    public static final String WRITE_CL                      = "spark.consistency.write";    // LOCAL_QUORUM
+
+    static {
+           types.put(ORIGIN_CONNECT_HOST, PropertyType.STRING);
+           types.put(ORIGIN_CONNECT_PORT, PropertyType.NUMBER);
+        defaults.put(ORIGIN_CONNECT_PORT, "9042");
+           types.put(ORIGIN_CONNECT_SCB, PropertyType.STRING);
+           types.put(ORIGIN_CONNECT_USERNAME, PropertyType.STRING);
+           types.put(ORIGIN_CONNECT_PASSWORD, PropertyType.STRING);
+
+           types.put(TARGET_CONNECT_HOST, PropertyType.STRING);
+           types.put(TARGET_CONNECT_PORT, PropertyType.NUMBER);
+        defaults.put(TARGET_CONNECT_PORT, "9042");
+           types.put(TARGET_CONNECT_SCB, PropertyType.STRING);
+           types.put(TARGET_CONNECT_USERNAME, PropertyType.STRING);
+           types.put(TARGET_CONNECT_PASSWORD, PropertyType.STRING);
+
+           types.put(READ_CL, PropertyType.STRING);
+        defaults.put(READ_CL, "LOCAL_QUORUM");
+           types.put(WRITE_CL, PropertyType.STRING);
+        defaults.put(WRITE_CL, "LOCAL_QUORUM");
+    }
+
+    //==========================================================================
+    // Properties that describe the origin table
+    //==========================================================================
+    public static final String ORIGIN_KEYSPACE_TABLE  = "spark.origin.keyspaceTable";      // test.a1
+    public static final String ORIGIN_COLUMN_NAMES    = "spark.query.origin";              // comma-separated-partition-key,comma-separated-clustering-key,comma-separated-other-columns
+    public static final String ORIGIN_PARTITION_KEY   = "spark.query.origin.partitionKey"; // comma-separated-partition-key
+    public static final String ORIGIN_COLUMN_TYPES    = "spark.query.types";               // 9,1,4,3
+    public static final String ORIGIN_TTL_COLS        = "spark.query.ttl.cols";            // 2,3
+    public static final String ORIGIN_WRITETIME_COLS  = "spark.query.writetime.cols";      // 2,3
+    public static final String ORIGIN_IS_COUNTER      = "spark.counterTable";              // false
+    public static final String ORIGIN_COUNTER_CQL     = "spark.counterTable.cql";
+    public static final String ORIGIN_COUNTER_INDEXES = "spark.counterTable.cql.index";    // 0
+    static {
+           types.put(ORIGIN_KEYSPACE_TABLE, PropertyType.STRING);
+        required.add(ORIGIN_KEYSPACE_TABLE);
+           types.put(ORIGIN_COLUMN_NAMES, PropertyType.STRING_LIST);
+        required.add(ORIGIN_COLUMN_NAMES);
+           types.put(ORIGIN_COLUMN_TYPES, PropertyType.MIGRATION_TYPE_LIST);
+        required.add(ORIGIN_COLUMN_TYPES);
+           types.put(ORIGIN_PARTITION_KEY, PropertyType.STRING_LIST);
+        required.add(ORIGIN_PARTITION_KEY);
+           types.put(ORIGIN_TTL_COLS, PropertyType.NUMBER_LIST);
+           types.put(ORIGIN_WRITETIME_COLS, PropertyType.NUMBER_LIST);
+           types.put(ORIGIN_IS_COUNTER, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_IS_COUNTER, "false");
+           types.put(ORIGIN_COUNTER_CQL, PropertyType.STRING);
+           types.put(ORIGIN_COUNTER_INDEXES, PropertyType.NUMBER_LIST);
+        defaults.put(ORIGIN_COUNTER_INDEXES, "0");
+
+    }
+
+    //==========================================================================
+    // Properties that filter records from origin
+    //==========================================================================
+    public static final String ORIGIN_FILTER_CONDITION       = "spark.query.condition";
+    public static final String ORIGIN_FILTER_WRITETS_ENABLED = "spark.origin.writeTimeStampFilter";     // false
+    public static final String ORIGIN_FILTER_WRITETS_MIN     = "spark.origin.minWriteTimeStampFilter";  // 0
+    public static final String ORIGIN_FILTER_WRITETS_MAX     = "spark.origin.maxWriteTimeStampFilter";  // 4102444800000000
+    public static final String ORIGIN_FILTER_COLUMN_ENABLED  = "spark.origin.FilterData";               // false
+    public static final String ORIGIN_FILTER_COLUMN_NAME     = "spark.origin.FilterColumn";             // test
+    public static final String ORIGIN_FILTER_COLUMN_INDEX    = "spark.origin.FilterColumnIndex";        // 2
+    public static final String ORIGIN_FILTER_COLUMN_TYPE     = "spark.origin.FilterColumnType";         // 6%16
+    public static final String ORIGIN_FILTER_COLUMN_VALUE    = "spark.origin.FilterColumnValue";        // test
+    public static final String ORIGIN_COVERAGE_PERCENT       = "spark.coveragePercent";                 // 100
+    public static final String ORIGIN_HAS_RANDOM_PARTITIONER = "spark.origin.hasRandomPartitioner";     // false
+
+    public static final String ORIGIN_CHECK_COLSIZE_ENABLED      = "spark.origin.checkTableforColSize";            // false
+    public static final String ORIGIN_CHECK_COLSIZE_COLUMN_NAMES = "spark.origin.checkTableforColSize.cols";       // partition-key,clustering-key
+    public static final String ORIGIN_CHECK_COLSIZE_COLUMN_TYPES = "spark.origin.checkTableforColSize.cols.types"; // 9,1
+
+    static {
+           types.put(ORIGIN_FILTER_CONDITION, PropertyType.STRING);
+           types.put(ORIGIN_FILTER_WRITETS_ENABLED, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_FILTER_WRITETS_ENABLED, "false");
+           types.put(ORIGIN_FILTER_WRITETS_MIN, PropertyType.NUMBER);
+        defaults.put(ORIGIN_FILTER_WRITETS_MIN, "0");
+           types.put(ORIGIN_FILTER_WRITETS_MAX, PropertyType.NUMBER);
+        defaults.put(ORIGIN_FILTER_WRITETS_MAX, "0");
+           types.put(ORIGIN_FILTER_COLUMN_ENABLED, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_FILTER_COLUMN_ENABLED, "false");
+           types.put(ORIGIN_FILTER_COLUMN_NAME, PropertyType.STRING);
+           types.put(ORIGIN_FILTER_COLUMN_INDEX, PropertyType.NUMBER);
+        defaults.put(ORIGIN_FILTER_COLUMN_INDEX, "0");
+           types.put(ORIGIN_FILTER_COLUMN_TYPE, PropertyType.MIGRATION_TYPE);
+           types.put(ORIGIN_FILTER_COLUMN_VALUE, PropertyType.STRING);
+           types.put(ORIGIN_COVERAGE_PERCENT, PropertyType.NUMBER);
+        defaults.put(ORIGIN_COVERAGE_PERCENT, "100");
+           types.put(ORIGIN_HAS_RANDOM_PARTITIONER, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_HAS_RANDOM_PARTITIONER, "false");
+
+           types.put(ORIGIN_CHECK_COLSIZE_ENABLED, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_CHECK_COLSIZE_ENABLED, "false");
+           types.put(ORIGIN_CHECK_COLSIZE_COLUMN_NAMES, PropertyType.STRING_LIST);
+           types.put(ORIGIN_CHECK_COLSIZE_COLUMN_TYPES, PropertyType.MIGRATION_TYPE_LIST);
+    }
+
+    //==========================================================================
+    // Properties that describe the target table
+    //==========================================================================
+    public static final String TARGET_KEYSPACE_TABLE       = "spark.target.keyspaceTable";        // test.a1
+    public static final String TARGET_PRIMARY_KEY          = "spark.query.target.id";             // comma-separated-partition-key,comma-separated-clustering-key
+    public static final String TARGET_PRIMARY_KEY_TYPES    = "spark.query.target.id.types";       // 9,1,4,3
+    public static final String TARGET_COLUMN_NAMES         = "spark.query.target";
+    public static final String TARGET_CUSTOM_WRITETIME     = "spark.target.custom.writeTime";     // 0
+    public static final String TARGET_AUTOCORRECT_MISSING  = "spark.target.autocorrect.missing";  // false
+    public static final String TARGET_AUTOCORRECT_MISMATCH = "spark.target.autocorrect.mismatch"; // false
+    public static final String TARGET_REPLACE_MISSING_TS   = "spark.target.replace.blankTimestampKeyUsingEpoch";
+    static {
+           types.put(TARGET_KEYSPACE_TABLE, PropertyType.STRING);
+        required.add(TARGET_KEYSPACE_TABLE);
+           types.put(TARGET_PRIMARY_KEY, PropertyType.STRING_LIST);
+        required.add(TARGET_PRIMARY_KEY);
+           types.put(TARGET_PRIMARY_KEY_TYPES, PropertyType.MIGRATION_TYPE_LIST);
+           types.put(TARGET_COLUMN_NAMES, PropertyType.STRING_LIST);
+        required.add(TARGET_COLUMN_NAMES); // we need this, though it should be defaulted with ORIGIN_COLUMN_NAMES value
+           types.put(TARGET_CUSTOM_WRITETIME, PropertyType.NUMBER);
+        defaults.put(TARGET_CUSTOM_WRITETIME, "0");
+           types.put(TARGET_AUTOCORRECT_MISSING, PropertyType.BOOLEAN);
+        defaults.put(TARGET_AUTOCORRECT_MISSING, "false");
+           types.put(TARGET_AUTOCORRECT_MISMATCH, PropertyType.BOOLEAN);
+        defaults.put(TARGET_AUTOCORRECT_MISMATCH, "false");
+           types.put(TARGET_REPLACE_MISSING_TS, PropertyType.NUMBER);
+    }
+
+    //==========================================================================
+    // Properties that adjust performance and error handling
+    //==========================================================================
+    public static final String SPARK_LIMIT_READ  = "spark.readRateLimit";         // 20000
+    public static final String SPARK_LIMIT_WRITE = "spark.writeRateLimit";        // 40000
+    public static final String SPARK_NUM_SPLITS  = "spark.numSplits";             // 10000, was spark.splitSize
+    public static final String DEPRECATED_SPARK_SPLIT_SIZE  = "spark.splitSize";  // 10000
+    public static final String SPARK_BATCH_SIZE  = "spark.batchSize";             // 5
+    public static final String SPARK_MAX_RETRIES = "spark.maxRetries";            // 0
+    public static final String READ_FETCH_SIZE   = "spark.read.fetch.sizeInRows"; //1000
+    public static final String SPARK_STATS_AFTER = "spark.printStatsAfter";       //100000
+    public static final String FIELD_GUARDRAIL   = "spark.fieldGuardraillimitMB"; //10
+    public static final String PARTITION_MIN     = "spark.origin.minPartition";   // -9223372036854775808
+    public static final String PARTITION_MAX     = "spark.origin.maxPartition";   // 9223372036854775807
+
+    static {
+           types.put(SPARK_LIMIT_READ, PropertyType.NUMBER);
+        defaults.put(SPARK_LIMIT_READ, "20000");
+           types.put(SPARK_LIMIT_WRITE, PropertyType.NUMBER);
+        defaults.put(SPARK_LIMIT_WRITE, "40000");
+           types.put(SPARK_NUM_SPLITS, PropertyType.NUMBER);
+        defaults.put(SPARK_NUM_SPLITS, "10000");
+           types.put(DEPRECATED_SPARK_SPLIT_SIZE, PropertyType.NUMBER);
+        defaults.put(DEPRECATED_SPARK_SPLIT_SIZE, "10000");
+           types.put(SPARK_BATCH_SIZE, PropertyType.NUMBER);
+        defaults.put(SPARK_BATCH_SIZE, "5");
+           types.put(SPARK_MAX_RETRIES, PropertyType.NUMBER);
+        defaults.put(SPARK_MAX_RETRIES, "0");
+           types.put(READ_FETCH_SIZE, PropertyType.NUMBER);
+        defaults.put(READ_FETCH_SIZE, "1000");
+           types.put(SPARK_STATS_AFTER, PropertyType.NUMBER);
+        defaults.put(SPARK_STATS_AFTER, "100000");
+           types.put(FIELD_GUARDRAIL, PropertyType.NUMBER);
+        defaults.put(FIELD_GUARDRAIL, "10");
+           types.put(PARTITION_MIN, PropertyType.NUMBER);
+        defaults.put(PARTITION_MIN, "-9223372036854775808");
+           types.put(PARTITION_MAX, PropertyType.NUMBER);
+        defaults.put(PARTITION_MAX, "9223372036854775807");
+
+    }
+
+    //==========================================================================
+    // Properties that configure origin TLS
+    //==========================================================================
+    public static final String ORIGIN_TLS_ENABLED             = "spark.origin.ssl.enabled";         // false
+    public static final String ORIGIN_TLS_TRUSTSTORE_PATH     = "spark.origin.trustStore.path";
+    public static final String ORIGIN_TLS_TRUSTSTORE_PASSWORD = "spark.origin.trustStore.password";
+    public static final String ORIGIN_TLS_TRUSTSTORE_TYPE     = "spark.origin.trustStore.type";     // JKS
+    public static final String ORIGIN_TLS_KEYSTORE_PATH       = "spark.origin.keyStore.path";
+    public static final String ORIGIN_TLS_KEYSTORE_PASSWORD   = "spark.origin.keyStore.password";
+    public static final String ORIGIN_TLS_ALGORITHMS          = "spark.origin.enabledAlgorithms";   // TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
+    static {
+           types.put(ORIGIN_TLS_ENABLED, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_TLS_ENABLED, "false");
+           types.put(ORIGIN_TLS_TRUSTSTORE_PATH, PropertyType.STRING);
+           types.put(ORIGIN_TLS_TRUSTSTORE_PASSWORD, PropertyType.STRING);
+           types.put(ORIGIN_TLS_TRUSTSTORE_TYPE, PropertyType.STRING);
+        defaults.put(ORIGIN_TLS_TRUSTSTORE_TYPE, "JKS");
+           types.put(ORIGIN_TLS_KEYSTORE_PATH, PropertyType.STRING);
+           types.put(ORIGIN_TLS_KEYSTORE_PASSWORD, PropertyType.STRING);
+           types.put(ORIGIN_TLS_ALGORITHMS, PropertyType.STRING); // This is a list but it is handled by Spark
+        defaults.put(ORIGIN_TLS_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA");
+    }
+
+    //==========================================================================
+    // Properties that configure target TLS
+    //==========================================================================
+    public static final String TARGET_TLS_ENABLED             = "spark.target.ssl.enabled";         // false
+    public static final String TARGET_TLS_TRUSTSTORE_PATH     = "spark.target.trustStore.path";
+    public static final String TARGET_TLS_TRUSTSTORE_PASSWORD = "spark.target.trustStore.password";
+    public static final String TARGET_TLS_TRUSTSTORE_TYPE     = "spark.target.trustStore.type";     // JKS
+    public static final String TARGET_TLS_KEYSTORE_PATH       = "spark.target.keyStore.path";
+    public static final String TARGET_TLS_KEYSTORE_PASSWORD   = "spark.target.keyStore.password";
+    public static final String TARGET_TLS_ALGORITHMS          = "spark.target.enabledAlgorithms";   // TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
+    static {
+           types.put(TARGET_TLS_ENABLED, PropertyType.BOOLEAN);
+        defaults.put(TARGET_TLS_ENABLED, "false");
+           types.put(TARGET_TLS_TRUSTSTORE_PATH, PropertyType.STRING);
+           types.put(TARGET_TLS_TRUSTSTORE_PASSWORD, PropertyType.STRING);
+           types.put(TARGET_TLS_TRUSTSTORE_TYPE, PropertyType.STRING);
+        defaults.put(TARGET_TLS_TRUSTSTORE_TYPE, "JKS");
+           types.put(TARGET_TLS_KEYSTORE_PATH, PropertyType.STRING);
+           types.put(TARGET_TLS_KEYSTORE_PASSWORD, PropertyType.STRING);
+           types.put(TARGET_TLS_ALGORITHMS, PropertyType.STRING); // This is a list but it is handled by Spark
+        defaults.put(TARGET_TLS_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA");
+    }
+
+    //==========================================================================
+    // Properties used for Unit Testing
+    //==========================================================================
+    public static final String TEST_STRING = "test.string";
+    protected static final String TEST_STRING_DEFAULT = "text";
+    public static final String TEST_STRING_NO_DEFAULT = "test.string.noDefault";
+    public static final String TEST_STRING_LIST = "test.stringList";
+    protected static final String TEST_STRING_LIST_DEFAULT = "text1,text2";
+    public static final String TEST_NUMBER = "test.number";
+    protected static final String TEST_NUMBER_DEFAULT = "1";
+    public static final String TEST_NUMBER_LIST = "test.numberList";
+    protected static final String TEST_NUMBER_LIST_DEFAULT = "1,2";
+    public static final String TEST_BOOLEAN = "test.boolean";
+    protected static final String TEST_BOOLEAN_DEFAULT = "true";
+    public static final String TEST_MIGRATE_TYPE = "test.migrateType";
+    protected static final String TEST_MIGRATE_TYPE_DEFAULT = "0";
+    public static final String TEST_MIGRATE_TYPE_LIST = "test.migrateTypeList";
+    protected static final String TEST_MIGRATE_TYPE_LIST_DEFAULT = "0,1,2";
+    public static final String TEST_UNHANDLED_TYPE = "test.unhandled.type";
+    static {
+           types.put(TEST_STRING, PropertyType.STRING);
+        defaults.put(TEST_STRING, TEST_STRING_DEFAULT);
+           types.put(TEST_STRING_NO_DEFAULT, PropertyType.STRING);
+           types.put(TEST_STRING_LIST, PropertyType.STRING_LIST);
+        defaults.put(TEST_STRING_LIST, TEST_STRING_LIST_DEFAULT);
+           types.put(TEST_NUMBER, PropertyType.NUMBER);
+        defaults.put(TEST_NUMBER, TEST_NUMBER_DEFAULT);
+           types.put(TEST_NUMBER_LIST, PropertyType.NUMBER_LIST);
+        defaults.put(TEST_NUMBER_LIST, TEST_NUMBER_LIST_DEFAULT);
+           types.put(TEST_BOOLEAN, PropertyType.BOOLEAN);
+        defaults.put(TEST_BOOLEAN, TEST_BOOLEAN_DEFAULT);
+           types.put(TEST_MIGRATE_TYPE, PropertyType.MIGRATION_TYPE);
+        defaults.put(TEST_MIGRATE_TYPE, TEST_MIGRATE_TYPE_DEFAULT);
+           types.put(TEST_MIGRATE_TYPE_LIST, PropertyType.MIGRATION_TYPE_LIST);
+        defaults.put(TEST_MIGRATE_TYPE_LIST, TEST_MIGRATE_TYPE_LIST_DEFAULT);
+           types.put(TEST_UNHANDLED_TYPE, PropertyType.TEST_UNHANDLED_TYPE);
+    }
+
+    public static Boolean isKnown(String key) {
+        return types.containsKey(key);
+    }
+
+    public static Object asType(PropertyType propertyType, String propertyValue) {
+        switch (propertyType) {
+            case STRING:
+                return propertyValue;
+            case STRING_LIST:
+                return Arrays.asList(propertyValue.split(","));
+            case NUMBER:
+                try {
+                    return Long.parseLong(propertyValue);
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            case NUMBER_LIST:
+                String[] numValues = propertyValue.split(",");
+                ArrayList<Number> numbers = new ArrayList<>(numValues.length);
+                try {
+                    for (String value : numValues) {
+                        numbers.add(Long.parseLong(value));
+                    }
+                    return numbers;
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            case BOOLEAN:
+                return Boolean.parseBoolean(propertyValue);
+            case MIGRATION_TYPE:
+                return new MigrateDataType(propertyValue);
+            case MIGRATION_TYPE_LIST:
+                String[] typeValues = propertyValue.split(",");
+                ArrayList<MigrateDataType> types = new ArrayList<>(typeValues.length);
+                for (String value : typeValues) {
+                    types.add(new MigrateDataType(value));
+                }
+                return types;
+            default:
+                throw new IllegalArgumentException("Unhandled property type: " + propertyType);
+        }
+    }
+
+    public static Object getDefault(String key) {
+        PropertyType type = types.get(key);
+        String value = defaults.get(key);
+        if (type == null ||
+                value == null) {
+            return null;
+        }
+        return asType(type, value);
+    }
+
+    public static String getDefaultAsString(String key) {
+        return defaults.get(key);
+    }
+
+    public static PropertyType getType(String key) {
+        return types.get(key);
+    }
+
+    public static Map<String,PropertyType> getTypeMap() { return types;}
+
+    public static Set<String> getRequired() { return required; }
+
+    public static boolean validateType(PropertyType expectedType, Object value) {
+        switch (expectedType) {
+            case STRING:
+                if (value instanceof String) {
+                    return true;
+                }
+                break;
+            case STRING_LIST:
+                if (value instanceof List<?>) {
+                    List<?> list = (List<?>) value;
+                    if (list.isEmpty()) {
+                        return false;
+                    } else {
+                        for (Object o : list) {
+                            if (!(o instanceof String)) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+                break;
+            case NUMBER:
+                if (value instanceof Number) {
+                    return true;
+                }
+                break;
+            case NUMBER_LIST:
+                if (value instanceof List<?>) {
+                    List<?> list = (List<?>) value;
+                    if (list.isEmpty()) {
+                        return false;
+                    } else {
+                        for (Object o : list) {
+                            if (!(o instanceof Number)) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+                break;
+            case BOOLEAN:
+                if (value instanceof Boolean) {
+                    return true;
+                }
+                break;
+            case MIGRATION_TYPE:
+                if ((value instanceof MigrateDataType) && ((MigrateDataType) value).isValid()) {
+                    return true;
+                }
+                break;
+            case MIGRATION_TYPE_LIST:
+                if (value instanceof List<?>) {
+                    List<?> list = (List<?>) value;
+                    if (list.isEmpty()) {
+                        return false;
+                    } else {
+                        for (Object o : list) {
+                            if (!(o instanceof MigrateDataType) || !((MigrateDataType) o).isValid()) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+        return false;
+    }
+}

--- a/src/main/java/datastax/astra/migrate/properties/PropertyHelper.java
+++ b/src/main/java/datastax/astra/migrate/properties/PropertyHelper.java
@@ -1,0 +1,349 @@
+package datastax.astra.migrate.properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import datastax.astra.migrate.MigrateDataType;
+import org.apache.commons.lang.StringUtils;
+import org.apache.spark.SparkConf;
+import scala.Tuple2;
+
+import java.util.*;
+
+public final class PropertyHelper extends KnownProperties{
+    private static PropertyHelper instance = null;
+
+    public Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+    private final Map<String,Object> propertyMap;
+    private volatile SparkConf sparkConf;
+    private boolean sparkConfFullyLoaded = false;
+
+    // As this is a singleton class, the constructor is private
+    private PropertyHelper() {
+        super();
+        propertyMap = new HashMap<>();
+    }
+
+    public static PropertyHelper getInstance() {
+        if (instance == null) {
+            synchronized (PropertyHelper.class) {
+                if (instance == null) {
+                    instance = new PropertyHelper();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public static PropertyHelper getInstance(SparkConf sc) {
+        instance = getInstance();
+        instance.initializeSparkConf(sc);
+        return instance;
+    }
+
+    public static void destroyInstance() {
+        if (instance != null) {
+            synchronized (PropertyHelper.class) {
+                if (instance != null) {
+                    instance = null;
+                }
+            }
+        }
+    }
+
+    /**
+     * Loads the SparkConf into the propertyMap, but only
+     * if the SparkConf has not already been loaded.
+     *
+     * @param sc
+     */
+    public void initializeSparkConf(SparkConf sc) {
+        if (null == sc)
+            throw new IllegalArgumentException("SparkConf cannot be null");
+
+        if (null == this.sparkConf)
+            synchronized (PropertyHelper.class) {
+                if (null == this.sparkConf) {
+                    this.sparkConf = sc;
+                    loadSparkConf();
+                }
+            }
+    }
+
+    /**
+     * Sets a property value if it is of the correct and known type.
+     * For _LIST types, the property will only be set if the list is not empty.
+     * @param propertyName
+     * @param propertyValue
+     * @return propertyValue if it is of the correct type, null otherwise
+     */
+    public Object setProperty(String propertyName, Object propertyValue) {
+        if (null == propertyName ||
+                null == propertyValue)
+            return null;
+        PropertyType expectedType = getType(propertyName);
+        if (null == expectedType) {
+            return null;
+        }
+
+        boolean typesMatch = validateType(expectedType, propertyValue);
+        if (!typesMatch)
+            return null;
+
+        synchronized (PropertyHelper.class) {
+            propertyMap.put(propertyName, propertyValue);
+        }
+        return propertyValue;
+    }
+
+    protected Object get(String propertyName) {
+        if (null == propertyName)
+            return null;
+
+        Object currentProperty;
+        synchronized (PropertyHelper.class){
+            currentProperty = propertyMap.get(propertyName);
+        }
+        return currentProperty;
+    }
+
+    protected Object get(String propertyName, PropertyType expectedType) {
+        if (null == propertyName
+                || null == expectedType
+                || expectedType != getType(propertyName)) {
+            return null;
+        }
+        Object currentProperty = get(propertyName);
+
+        if (validateType(expectedType, currentProperty)) {
+            return currentProperty;
+        } else {
+            return null;
+        }
+    }
+
+    public String getString(String propertyName) {
+        String rtn = (String) get(propertyName, PropertyType.STRING);
+        return (null == rtn) ? "" : rtn;
+    }
+
+    public List<String> getStringList(String propertyName) {
+        return (List<String>) get(propertyName, PropertyType.STRING_LIST);
+    }
+
+    public Number getNumber(String propertyName) {
+        return (Number) get(propertyName, PropertyType.NUMBER);
+    }
+
+    public Integer getInteger(String propertyName) {
+        if (null==getNumber(propertyName)
+                || PropertyType.NUMBER != getType(propertyName))
+            return null;
+        return toInteger(getNumber(propertyName));
+    }
+
+    public Long getLong(String propertyName) {
+        if (null==getNumber(propertyName)
+                || PropertyType.NUMBER != getType(propertyName))
+            return null;
+        return getNumber(propertyName).longValue();
+    }
+
+    public List<Number> getNumberList(String propertyName) {
+        return (List<Number>) get(propertyName, PropertyType.NUMBER_LIST);
+    }
+
+    public List<Integer> getIntegerList(String propertyName) {
+        List<Integer> intList = new ArrayList<>();
+        Integer i;
+        if (null==propertyName
+                || PropertyType.NUMBER_LIST != getType(propertyName)
+                || null==getNumberList(propertyName))
+            return null;
+        for (Number n : getNumberList(propertyName)) {
+            i = toInteger(n);
+            if (null == i)
+                return null;
+            intList.add(i);
+        }
+        return intList;
+    }
+
+    public Boolean getBoolean(String propertyName) {
+        return (Boolean) get(propertyName, PropertyType.BOOLEAN);
+    }
+
+    public MigrateDataType getMigrationType(String propertyName) {
+        return (MigrateDataType) get(propertyName, PropertyType.MIGRATION_TYPE);
+    }
+
+    public List<MigrateDataType> getMigrationTypeList(String propertyName) {
+        return (List<MigrateDataType>) get(propertyName, PropertyType.MIGRATION_TYPE_LIST);
+    }
+
+    public String getAsString(String propertyName) {
+        String rtn;
+        if (null == propertyName)
+            return null;
+        Object propertyValue = get(propertyName, getType(propertyName));
+        if (null == propertyValue)
+            return "";
+        switch (getType(propertyName)) {
+            case STRING:
+                rtn = (String) propertyValue;
+                break;
+            case STRING_LIST:
+            case NUMBER_LIST:
+            case MIGRATION_TYPE_LIST:
+                rtn = StringUtils.join((List<?>) propertyValue, ",");
+                break;
+            case NUMBER:
+            case BOOLEAN:
+            case MIGRATION_TYPE:
+            default:
+                rtn = propertyValue.toString();
+        }
+        return (null == rtn) ? "" : rtn;
+    }
+
+    protected void loadSparkConf() {
+        boolean fullyLoaded = true;
+        Object setValue;
+
+        logger.info("Processing explicitly set and known sparkConf properties");
+        for (Tuple2<String,String> kvp : sparkConf.getAll()) {
+            String scKey = kvp._1();
+            String scValue = kvp._2();
+;
+            if (KnownProperties.isKnown(scKey)) {
+                PropertyType propertyType = KnownProperties.getType(scKey);
+                setValue = setProperty(scKey, KnownProperties.asType(propertyType,scValue));
+                if (null == setValue) {
+                    logger.error("Unable to set property: [" + scKey + "], value: [" + scValue + "] with type: [" + propertyType +"]");
+                    fullyLoaded = false;
+                } else {
+                    logger.info("Known property [" + scKey + "] is configured with value [" + scValue + "] and is type [" + propertyType + "]");
+                }
+            }
+        }
+
+        logger.info("Adding any missing known properties that have default values");
+        for (String knownProperty : KnownProperties.getTypeMap().keySet()) {
+            if (null == get(knownProperty)) {
+                Object defaultValue = KnownProperties.getDefault(knownProperty);
+                if (null != defaultValue) {
+                    logger.info("Setting known property [" + knownProperty + "] with default value [" + KnownProperties.getDefaultAsString(knownProperty) + "]");
+                    setProperty(knownProperty, defaultValue);
+                }
+            }
+        }
+
+        // Target column list defaults to the source column list
+        if (null == get(KnownProperties.TARGET_COLUMN_NAMES) || getAsString(KnownProperties.TARGET_COLUMN_NAMES).isEmpty()) {
+            String originColumnNames = getAsString(KnownProperties.ORIGIN_COLUMN_NAMES);
+            logger.info("Setting known property [" + KnownProperties.TARGET_COLUMN_NAMES + "] with value from [" + KnownProperties.ORIGIN_COLUMN_NAMES + "], which is [" + getAsString(KnownProperties.ORIGIN_COLUMN_NAMES) + "]");
+            setProperty(KnownProperties.TARGET_COLUMN_NAMES, get(KnownProperties.ORIGIN_COLUMN_NAMES));
+        }
+
+        // Target column key list defaults to the first N columns of the source column list, where N is the size of the target primary key list
+        if (null == get(KnownProperties.TARGET_PRIMARY_KEY_TYPES) || getAsString(KnownProperties.TARGET_PRIMARY_KEY_TYPES).isEmpty()) {
+            if (null != getMigrationTypeList(KnownProperties.ORIGIN_COLUMN_TYPES) && !getMigrationTypeList(KnownProperties.ORIGIN_COLUMN_TYPES).isEmpty()) {
+                List<MigrateDataType> targetPKTypes = getMigrationTypeList(KnownProperties.ORIGIN_COLUMN_TYPES).subList(0, getStringList(KnownProperties.TARGET_PRIMARY_KEY).size());
+                logger.info("Setting known property [" + KnownProperties.TARGET_PRIMARY_KEY_TYPES + "] based on [" + KnownProperties.ORIGIN_COLUMN_TYPES + "], which is [" + getAsString(KnownProperties.ORIGIN_COLUMN_TYPES) + "]");
+                setProperty(KnownProperties.TARGET_PRIMARY_KEY_TYPES, targetPKTypes);
+            }
+        }
+
+        if (fullyLoaded) {
+            fullyLoaded = isValidConfig();
+        }
+
+        this.sparkConfFullyLoaded = fullyLoaded;
+    }
+
+    protected boolean isValidConfig() {
+        boolean valid = true;
+
+        // First check over the simple-to-discover required properties
+        for (String requiredProperty : KnownProperties.getRequired()) {
+            if (null == get(requiredProperty) || getAsString(requiredProperty).isEmpty()) {
+                logger.error("Missing required property: " + requiredProperty);
+                valid = false;
+            }
+        }
+
+        // Check we have a configured origin connection
+        if ( (null == get(KnownProperties.ORIGIN_CONNECT_HOST) && null == get(KnownProperties.ORIGIN_CONNECT_SCB)) ||
+                getAsString(KnownProperties.ORIGIN_CONNECT_HOST).isEmpty() && getAsString(KnownProperties.ORIGIN_CONNECT_SCB).isEmpty()) {
+            logger.error("Missing required property: " + KnownProperties.ORIGIN_CONNECT_HOST + " or " + KnownProperties.ORIGIN_CONNECT_SCB);
+            valid = false;
+        } else {
+            // Validate TLS configuration is set if so-enabled
+            if (null == get(KnownProperties.ORIGIN_CONNECT_SCB) && null != get(KnownProperties.ORIGIN_TLS_ENABLED) && getBoolean(KnownProperties.ORIGIN_TLS_ENABLED)) {
+                for (String expectedProperty : new String[]{KnownProperties.ORIGIN_TLS_TRUSTSTORE_PATH, KnownProperties.ORIGIN_TLS_TRUSTSTORE_PASSWORD,
+                        KnownProperties.ORIGIN_TLS_TRUSTSTORE_TYPE, KnownProperties.ORIGIN_TLS_KEYSTORE_PATH, KnownProperties.ORIGIN_TLS_KEYSTORE_PASSWORD,
+                        KnownProperties.ORIGIN_TLS_ALGORITHMS}) {
+                    if (null == get(expectedProperty) || getAsString(expectedProperty).isEmpty()) {
+                        logger.error("TLS is enabled, but required value is not set: " + expectedProperty);
+                        valid = false;
+                    }
+                }
+            }
+        }
+
+        // Check we have a configured target connection
+        if ( (null == get(KnownProperties.TARGET_CONNECT_HOST) && null == get(KnownProperties.TARGET_CONNECT_SCB)) ||
+                getAsString(KnownProperties.TARGET_CONNECT_HOST).isEmpty() && getAsString(KnownProperties.TARGET_CONNECT_SCB).isEmpty()) {
+            logger.error("Missing required property: " + KnownProperties.TARGET_CONNECT_HOST + " or " + KnownProperties.TARGET_CONNECT_SCB);
+            valid = false;
+        } else {
+            // Validate TLS configuration is set if so-enabled
+            if (null == get(KnownProperties.TARGET_CONNECT_SCB) && null != get(KnownProperties.TARGET_TLS_ENABLED) && getBoolean(KnownProperties.TARGET_TLS_ENABLED)) {
+                for (String expectedProperty : new String[]{KnownProperties.TARGET_TLS_TRUSTSTORE_PATH, KnownProperties.TARGET_TLS_TRUSTSTORE_PASSWORD,
+                        KnownProperties.TARGET_TLS_TRUSTSTORE_TYPE, KnownProperties.TARGET_TLS_KEYSTORE_PATH, KnownProperties.TARGET_TLS_KEYSTORE_PASSWORD,
+                        KnownProperties.TARGET_TLS_ALGORITHMS}) {
+                    if (null == get(expectedProperty) || getAsString(expectedProperty).isEmpty()) {
+                        logger.error("TLS is enabled, but required value is not set: " + expectedProperty);
+                        valid = false;
+                    }
+                }
+            }
+        }
+        
+        // Expecting these to normally be set, but it could be a valid configuration
+        for (String expectedProperty : new String[]{KnownProperties.ORIGIN_CONNECT_USERNAME, KnownProperties.ORIGIN_CONNECT_PASSWORD, KnownProperties.TARGET_CONNECT_USERNAME, KnownProperties.TARGET_CONNECT_PASSWORD}) {
+            if (null == get(expectedProperty) || getAsString(expectedProperty).isEmpty()) {
+                logger.warn("Unusual this is not set: " + expectedProperty);
+            }
+        }
+
+        return valid;
+    }
+
+    private Integer toInteger(Number n) {
+        if (n instanceof Integer
+                || n instanceof Short
+                || n instanceof Byte)
+            return n.intValue();
+        else if (n instanceof Long) {
+            if ((Long) n >= Integer.MIN_VALUE && (Long) n <= Integer.MAX_VALUE) {
+                return n.intValue();
+            }
+        }
+        return null;
+    }
+
+    protected Map<String,Object> getPropertyMap() {
+        return propertyMap;
+    }
+
+    public boolean isSparkConfFullyLoaded() {
+        return sparkConfFullyLoaded;
+    }
+
+    public boolean meetsMinimum(String valueName, Integer testValue, Integer minimumValue) {
+        if (null != minimumValue && null != testValue && testValue >= minimumValue)
+            return true;
+        logger.warn(valueName + " must be greater than or equal to " + minimumValue + ".  Current value does not meet this requirement: " + testValue);
+        return false;
+    }
+}

--- a/src/main/scala/datastax/astra/migrate/BaseJob.scala
+++ b/src/main/scala/datastax/astra/migrate/BaseJob.scala
@@ -18,7 +18,7 @@ class BaseJob extends App {
   val sContext = spark.sparkContext
   val sc = sContext.getConf
 
-  val consistencyLevel = Util.getSparkPropOr(sc, "spark.read.consistency.level", "LOCAL_QUORUM")
+  val consistencyLevel = Util.getSparkPropOr(sc, "spark.consistency.read", "LOCAL_QUORUM")
 
   val sourceScbPath = Util.getSparkPropOrEmpty(sc, "spark.origin.scb")
   val sourceHost = Util.getSparkPropOrEmpty(sc, "spark.origin.host")

--- a/src/test/java/datastax/astra/migrate/properties/KnownPropertiesTest.java
+++ b/src/test/java/datastax/astra/migrate/properties/KnownPropertiesTest.java
@@ -1,0 +1,226 @@
+package datastax.astra.migrate.properties;
+
+import datastax.astra.migrate.MigrateDataType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static datastax.astra.migrate.properties.KnownProperties.TEST_NUMBER_LIST_DEFAULT;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KnownPropertiesTest {
+
+    @Test
+    public void getDefault_knownDefault() {
+        assertEquals("text",KnownProperties.getDefaultAsString(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void getDefault_knownNoDefault() {
+        assertNull(KnownProperties.getDefaultAsString(KnownProperties.TEST_STRING_NO_DEFAULT));
+    }
+
+    @Test
+    public void getDefault_unknownValue() {
+        assertNull(KnownProperties.getDefaultAsString("unknown"));
+    }
+
+    @Test
+    public void getDefault_nullKey() {
+        assertNull(KnownProperties.getDefaultAsString(null));
+    }
+
+    @Test
+    public void getType_knownType() {
+        assertEquals(KnownProperties.PropertyType.STRING, KnownProperties.getType(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void getType_unknownValue() {
+        assertNull(KnownProperties.getType("unknown"));
+    }
+
+    @Test
+    public void getType_nullKey() {
+        assertNull(KnownProperties.getType(null));
+    }
+
+    @Test
+    public void hasDefault_known() {
+        assertTrue(KnownProperties.isKnown(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void hasDefault_unknown() {
+        assertFalse(KnownProperties.isKnown("unknown"));
+    }
+
+    @Test
+    public void asType_String() {
+        String value = "test";
+        assertEquals(value, KnownProperties.asType(KnownProperties.PropertyType.STRING, value));
+    }
+
+    @Test
+    public void asType_StringList() {
+        String value = "a,b,c";
+        assertEquals(Arrays.asList(value.split(",")), KnownProperties.asType(KnownProperties.PropertyType.STRING_LIST, value));
+    }
+
+    @Test
+    public void asType_Number() {
+        Long value = Long.MAX_VALUE;
+        assertEquals(value, KnownProperties.asType(KnownProperties.PropertyType.NUMBER, String.valueOf(value)));
+    }
+
+    @Test
+    public void asType_Number_Invalid() {
+        assertNull(KnownProperties.asType(KnownProperties.PropertyType.NUMBER, "x"));
+    }
+
+    @Test
+    public void asType_NumberList() {
+        assertEquals(Arrays.asList(1L,2L,3L), KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST, "1,2,3"));
+    }
+
+    @Test
+    public void asType_NumberList_Invalid() {
+        assertNull(KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST, "1,2,x,4"));
+    }
+
+    @Test
+    public void asType_Boolean() {
+        assertEquals(true, KnownProperties.asType(KnownProperties.PropertyType.BOOLEAN, "true"));
+    }
+
+    @Test
+    public void asType_MigrationType() {
+        assertEquals(new MigrateDataType("1"), KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE, "1"));
+    }
+
+    @Test
+    public void asType_MigrationTypeList() {
+        assertEquals(Arrays.asList(new MigrateDataType("1"),new MigrateDataType("0")), KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, "1,0"));
+    }
+
+    @Test
+    public void asType_unhandledType() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            KnownProperties.asType(KnownProperties.PropertyType.TEST_UNHANDLED_TYPE, "1");
+        });
+        assertTrue(exception.getMessage().contains("Unhandled property type: TEST_UNHANDLED_TYPE"));
+    }
+
+    @Test
+    public void getDefaultAsString_NumberList() {
+        assertEquals(TEST_NUMBER_LIST_DEFAULT, KnownProperties.getDefaultAsString(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getDefault_NumberList() {
+        assertEquals(Arrays.asList(1L,2L), KnownProperties.getDefault(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getDefault_nullArgument() {
+        assertNull(KnownProperties.getDefault(null));
+    }
+
+    @Test
+    public void getDefault_noDefault() {
+        assertNull(KnownProperties.getDefault(KnownProperties.TEST_STRING_NO_DEFAULT));
+    }
+
+    @Test
+    public void getTypeMap() {
+        assertNotNull(KnownProperties.getTypeMap());
+        assertEquals(KnownProperties.PropertyType.STRING, KnownProperties.getTypeMap().get(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void getRequired() {
+        assertNotNull(KnownProperties.getRequired());
+        assertTrue(!KnownProperties.getRequired().isEmpty());
+    }
+
+    @Test
+    public void validateType_String() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.STRING, "test"));
+    }
+
+    @Test
+    public void validateType_String_notString() {
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.STRING, 1L));
+    }
+
+    @Test
+    public void validateType_StringList() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.STRING_LIST, KnownProperties.asType(KnownProperties.PropertyType.STRING_LIST,"a,b,c")));
+    }
+
+    @Test
+    public void validateType_StringList_Empty() {
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.STRING_LIST, new ArrayList<String>()));
+    }
+
+    @Test
+    public void validateType_StringList_MixedList() {
+        ArrayList<Object> list = new ArrayList<>(2);
+        list.add("a");
+        list.add(1L);
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.STRING_LIST, list));
+    }
+
+    @Test
+    public void validateType_Number() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.NUMBER, KnownProperties.asType(KnownProperties.PropertyType.NUMBER,"1")));
+    }
+
+    @Test
+    public void validateType_NumberList() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.NUMBER_LIST, KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST,"1,2,3")));
+    }
+
+    @Test
+    public void validateType_NumberList_Empty() {
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.NUMBER_LIST, new ArrayList<Number>()));
+    }
+
+    @Test
+    public void validateType_NumberList_MixedList() {
+        ArrayList<Object> list = new ArrayList<>(2);
+        list.add(1L);
+        list.add("a");
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.NUMBER_LIST, list));
+    }
+
+    @Test
+    public void validateType_Boolean() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.BOOLEAN, KnownProperties.asType(KnownProperties.PropertyType.BOOLEAN,"false")));
+    }
+
+    @Test
+    public void validateType_MigrationType() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.MIGRATION_TYPE, KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE,"0")));
+    }
+
+    @Test
+    public void validateType_MigrationTypeList() {
+        assertTrue(KnownProperties.validateType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST,"0,2,3")));
+    }
+
+    @Test
+    public void validateType_MigrationTypeListt_Empty() {
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, new ArrayList<Number>()));
+    }
+
+    @Test
+    public void validateType_MigrationTypeList_MixedList() {
+        ArrayList<Object> list = new ArrayList<>(2);
+        list.add("1");
+        list.add("a");
+        assertFalse(KnownProperties.validateType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, list));
+    }
+
+}

--- a/src/test/java/datastax/astra/migrate/properties/PropertyHelperTest.java
+++ b/src/test/java/datastax/astra/migrate/properties/PropertyHelperTest.java
@@ -1,0 +1,573 @@
+package datastax.astra.migrate.properties;
+
+import java.util.List;
+import java.util.Arrays;
+
+import datastax.astra.migrate.MigrateDataType;
+import org.apache.spark.SparkConf;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PropertyHelperTest {
+    PropertyHelper helper;
+    SparkConf validSparkConf;
+
+    @BeforeEach
+    public void setup() {
+        helper = PropertyHelper.getInstance();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PropertyHelper.destroyInstance();
+        validSparkConf = null;
+    }
+
+    @Test
+    public void setProperty_String() {
+        String value = "test_value";
+        String setValue = (String) helper.setProperty(KnownProperties.TEST_STRING, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_StringList() {
+        List<String> value = Arrays.asList("a","b", "c");
+        List<String> setValue = (List<String>) helper.setProperty(KnownProperties.TEST_STRING_LIST, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_StringList_oneValue() {
+        List<String> value = Arrays.asList("a");
+        List<String> setValue = (List<String>) helper.setProperty(KnownProperties.TEST_STRING_LIST, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_StringList_splitString() {
+        String list = "a,b,c";
+        List<String> setValue = (List<String>) helper.setProperty(KnownProperties.TEST_STRING_LIST, KnownProperties.asType(KnownProperties.PropertyType.STRING_LIST, list));
+        assertEquals(Arrays.asList(list.split(",")), setValue);
+    }
+
+    @Test
+    public void setProperty_StringList_splitString_oneValue() {
+        String list = "a";
+        List<String> setValue = (List<String>) helper.setProperty(KnownProperties.TEST_STRING_LIST, KnownProperties.asType(KnownProperties.PropertyType.STRING_LIST, list));
+        assertEquals(Arrays.asList(list), setValue);
+    }
+
+    @Test
+    public void setProperty_StringList_empty() {
+        List<String> value = Arrays.asList();
+        List<String> setValue = (List<String>) helper.setProperty(KnownProperties.TEST_STRING_LIST, value);
+        assertNull(setValue);
+    }
+
+    @Test
+    public void setProperty_Number() {
+        Integer value = 1234;
+        Integer setValue = (Integer) helper.setProperty(KnownProperties.TEST_NUMBER, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_NumberList() {
+        List<Integer> value = Arrays.asList(1,2,3,4);
+        List<Integer> setValue = (List<Integer>) helper.setProperty(KnownProperties.TEST_NUMBER_LIST, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_NumberList_splitString() {
+        String list = "1,2,3,4";
+        List<Long> setValue = (List<Long>) helper.setProperty(KnownProperties.TEST_NUMBER_LIST, KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST, list));
+        assertEquals(Arrays.asList(1L,2L,3L,4L), setValue);
+    }
+
+    @Test
+    public void setProperty_NumberList_splitString_oneValue() {
+        String list = "1";
+        List<Long> setValue = (List<Long>) helper.setProperty(KnownProperties.TEST_NUMBER_LIST, KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST, list));
+        assertEquals(Arrays.asList(1L), setValue);
+    }
+
+    @Test
+    public void setProperty_NumberList_splitString_LongValue() {
+        String list = String.valueOf(Long.MAX_VALUE);
+        List<Long> setValue = (List<Long>) helper.setProperty(KnownProperties.TEST_NUMBER_LIST, KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST, list));
+        assertEquals(Arrays.asList(Long.MAX_VALUE), setValue);
+    }
+
+    @Test
+    public void setProperty_NumberList_splitString_badNumber() {
+        String list = "1,2,x,4";
+        List<Integer> setValue = (List<Integer>) helper.setProperty(KnownProperties.TEST_NUMBER_LIST, KnownProperties.asType(KnownProperties.PropertyType.NUMBER_LIST, list));
+        assertNull(setValue);
+    }
+
+    @Test
+    public void setProperty_NumberList_empty() {
+        List<String> value = Arrays.asList();
+        List<Integer> setValue = (List<Integer>) helper.setProperty(KnownProperties.TEST_NUMBER_LIST, value);
+        assertNull(setValue);
+    }
+
+    @Test
+    public void setProperty_Boolean() {
+        Boolean value = true;
+        Boolean setValue = (Boolean) helper.setProperty(KnownProperties.TEST_BOOLEAN, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_MigrateDataType() {
+        MigrateDataType value = new MigrateDataType("1");
+        MigrateDataType setValue = (MigrateDataType) helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_MigrateDataTypeList() {
+        List<MigrateDataType> value = Arrays.asList(new MigrateDataType("1"),new MigrateDataType("2"));
+        List<MigrateDataType> setValue = (List<MigrateDataType>) helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, value);
+        assertEquals(value, setValue);
+    }
+
+    @Test
+    public void setProperty_MigrateDataTypeList_splitString() {
+        String list = "1,0";
+        List<MigrateDataType> setValue = (List<MigrateDataType>) helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, list));
+        assertEquals(Arrays.asList(new MigrateDataType("1"),new MigrateDataType("0")), setValue);
+    }
+
+    @Test
+    public void setProperty_MigrateDataTypeList_splitString_oneValue() {
+        String list = "5%0%0";
+        List<MigrateDataType> setValue = (List<MigrateDataType>) helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, list));
+        assertEquals(Arrays.asList(new MigrateDataType("5%0%0")), setValue);
+    }
+
+    @Test
+    public void setProperty_MigrateDataTypeList_splitString_badType() {
+        String list = "1,2,x,4";
+        List<MigrateDataType> setValue = (List<MigrateDataType>) helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, KnownProperties.asType(KnownProperties.PropertyType.MIGRATION_TYPE_LIST, list));
+        assertNull(setValue);
+    }
+
+    @Test
+    public void setProperty_MigrateDataTypeList_empty() {
+        List<MigrateDataType> value = Arrays.asList();
+        List<MigrateDataType> setValue = (List<MigrateDataType>) helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, value);
+        assertNull(setValue);
+    }
+
+    @Test
+    public void setProperty_nullArguments() {
+        assertNull(helper.setProperty(null, "test"));
+        assertNull(helper.setProperty(KnownProperties.TEST_STRING, null));
+    }
+
+    @Test
+    public void setProperty_mismatchType() {
+        assertNull(helper.setProperty(KnownProperties.TEST_STRING, Integer.valueOf(1)));
+    }
+
+    @Test
+    public void setProperty_unknownType() {
+        assertNull(helper.setProperty(KnownProperties.TEST_UNHANDLED_TYPE, "abc"));
+    }
+
+    @Test
+    public void setProperty_unknownValue() {
+        assertNull(helper.setProperty("unknown.value", "abc"));
+    }
+
+    @Test
+    public void get_null() {
+        assertNull(helper.get(null));
+    }
+
+    @Test
+    public void getString() {
+        helper.setProperty(KnownProperties.TEST_STRING, "test");
+        assertEquals("test", helper.getString(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void getStringList() {
+        helper.setProperty(KnownProperties.TEST_STRING_LIST, Arrays.asList("a","b","c"));
+        assertEquals(Arrays.asList("a","b","c"), helper.getStringList(KnownProperties.TEST_STRING_LIST));
+    }
+
+    @Test
+    public void getNumber() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, 4321);
+        assertEquals(4321, helper.getNumber(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getNumber_NullValue() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, null);
+        assertNull(helper.getNumber(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getInteger_Integer() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, 1234);
+        assertEquals(Integer.valueOf(1234), helper.getInteger(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getInteger_Short() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, Short.MAX_VALUE);
+        assertEquals(Integer.valueOf(Short.MAX_VALUE), helper.getInteger(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getInteger_Byte() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, Byte.MAX_VALUE);
+        assertEquals(Integer.valueOf(Byte.MAX_VALUE), helper.getInteger(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getInteger_Long_smallValue() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, Long.parseLong("1234"));
+        assertEquals(Integer.valueOf(1234), helper.getInteger(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getInteger_Long_tooBigForInteger() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, Long.MIN_VALUE);
+        assertNull(helper.getInteger(KnownProperties.TEST_NUMBER));
+
+        helper.setProperty(KnownProperties.TEST_NUMBER, Long.MAX_VALUE);
+        assertNull(helper.getInteger(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getInteger_nullArgument() {
+        assertNull(helper.getInteger(null));
+    }
+
+    @Test
+    public void getInteger_wrongType() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1,2,3));
+        assertNull(helper.getInteger(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getLong() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, Long.MAX_VALUE);
+        assertEquals(Long.MAX_VALUE, (long) helper.getLong(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getLong_nullArgument() {
+        assertNull(helper.getLong(null));
+    }
+
+    @Test
+    public void getLong_wrongType() {
+        helper.setProperty(KnownProperties.TEST_STRING, String.valueOf(Long.MAX_VALUE));
+        assertNull(helper.getLong(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void getNumberList() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1,2,3));
+        assertEquals(Arrays.asList(1,2,3), helper.getNumberList(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getIntegerList() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1,2,3));
+        assertEquals(Arrays.asList(1,2,3), helper.getIntegerList(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getIntegerList_nullParameter() {
+        assertNull(helper.getIntegerList(null));
+    }
+
+    @Test
+    public void getIntegerList_nullValue() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1,null,3));
+        assertNull(helper.getIntegerList(null));
+    }
+
+    @Test
+    public void getIntegerList_wrongType() {
+        helper.setProperty(KnownProperties.TEST_STRING_LIST, Arrays.asList("1","2","3"));
+        assertNull(helper.getIntegerList(KnownProperties.TEST_STRING_LIST));
+    }
+
+    @Test
+    public void getIntegerList_notAllValuesFit() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1, Double.MAX_VALUE, 3));
+        assertNull(helper.getIntegerList(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getIntegerList_noListSet() {
+        assertNull(helper.getIntegerList(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getIntegerList_nullValueInList() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1, null, 3));
+        assertNull(helper.getIntegerList(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getBoolean() {
+        helper.setProperty(KnownProperties.TEST_BOOLEAN, false);
+        assertFalse(helper.getBoolean(KnownProperties.TEST_BOOLEAN));
+    }
+
+    @Test
+    public void getMigrationType() {
+        helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE, new MigrateDataType("1"));
+        assertEquals(new MigrateDataType("1"),helper.getMigrationType(KnownProperties.TEST_MIGRATE_TYPE));
+    }
+
+    @Test
+    public void getMigrationTypeList() {
+        helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, Arrays.asList(new MigrateDataType("1"),new MigrateDataType("3")));
+        assertEquals(Arrays.asList(new MigrateDataType("1"),new MigrateDataType("3")),helper.getMigrationTypeList(KnownProperties.TEST_MIGRATE_TYPE_LIST));
+    }
+
+    @Test
+    public void get_nullPropertyName() {
+        assertNull(helper.get(null, KnownProperties.PropertyType.STRING));
+    }
+
+    @Test
+    public void get_nullPropertyType() {
+        assertNull(helper.get(KnownProperties.TEST_STRING, null));
+    }
+
+    @Test
+    public void get_MismatchType() {
+        assertNull(helper.get(KnownProperties.TEST_STRING, KnownProperties.PropertyType.NUMBER));
+    }
+
+    @Test
+    public void get_nullPropertyValue() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, null);
+        assertNull(helper.get(KnownProperties.TEST_NUMBER, KnownProperties.PropertyType.NUMBER));
+    }
+
+    @Test
+    public void get_invalidType_String() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_STRING, "abcd");
+        helper.getPropertyMap().put(KnownProperties.TEST_STRING, Integer.valueOf(1234));
+        assertNull(helper.get(KnownProperties.TEST_STRING, KnownProperties.PropertyType.STRING));
+    }
+
+    @Test
+    public void get_invalidType_StringList() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_STRING_LIST, "a,b,c,d");
+        helper.getPropertyMap().put(KnownProperties.TEST_STRING_LIST, Arrays.asList(1,2,3,4));
+        assertNull(helper.get(KnownProperties.TEST_STRING_LIST, KnownProperties.PropertyType.STRING_LIST));
+    }
+
+    @Test
+    public void get_invalidType_Number() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_NUMBER, 1234);
+        helper.getPropertyMap().put(KnownProperties.TEST_NUMBER, "1234");
+        assertNull(helper.get(KnownProperties.TEST_NUMBER, KnownProperties.PropertyType.NUMBER));
+    }
+
+    @Test
+    public void get_invalidType_NumberList() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, "1,2,3,4");
+        helper.getPropertyMap().put(KnownProperties.TEST_NUMBER_LIST, Arrays.asList("a","b","c","d"));
+        assertNull(helper.get(KnownProperties.TEST_NUMBER_LIST, KnownProperties.PropertyType.NUMBER_LIST));
+    }
+
+    @Test
+    public void get_invalidType_Boolean() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_BOOLEAN, "true");
+        helper.getPropertyMap().put(KnownProperties.TEST_BOOLEAN, Integer.valueOf(1234));
+        assertNull(helper.get(KnownProperties.TEST_BOOLEAN, KnownProperties.PropertyType.BOOLEAN));
+    }
+
+    @Test
+    public void get_invalidType_MigrateDataType() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE, "1");
+        helper.getPropertyMap().put(KnownProperties.TEST_MIGRATE_TYPE, Integer.valueOf(1));
+        assertNull(helper.get(KnownProperties.TEST_MIGRATE_TYPE, KnownProperties.PropertyType.MIGRATION_TYPE));
+    }
+
+    @Test
+    public void get_invalidType_MigrateDataTypeList() {
+        // Any code that actually does this is broken, but we should handle it gracefully
+        helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, "1,1,2");
+        helper.getPropertyMap().put(KnownProperties.TEST_MIGRATE_TYPE_LIST, Arrays.asList(1,1,2));
+        assertNull(helper.get(KnownProperties.TEST_MIGRATE_TYPE_LIST, KnownProperties.PropertyType.MIGRATION_TYPE_LIST));
+    }
+
+    @Test
+    public void getAsString_String() {
+        helper.setProperty(KnownProperties.TEST_STRING, "abcd");
+        assertEquals("abcd", helper.getAsString(KnownProperties.TEST_STRING));
+    }
+
+    @Test
+    public void getAsString_StringList() {
+        helper.setProperty(KnownProperties.TEST_STRING_LIST, Arrays.asList("a","b","c","d"));
+        assertEquals("a,b,c,d", helper.getAsString(KnownProperties.TEST_STRING_LIST));
+    }
+
+    @Test
+    public void getAsString_Number() {
+        helper.setProperty(KnownProperties.TEST_NUMBER, 1234);
+        assertEquals("1234", helper.getAsString(KnownProperties.TEST_NUMBER));
+    }
+
+    @Test
+    public void getAsString_NumberList() {
+        helper.setProperty(KnownProperties.TEST_NUMBER_LIST, Arrays.asList(1,2,3,4));
+        assertEquals("1,2,3,4", helper.getAsString(KnownProperties.TEST_NUMBER_LIST));
+    }
+
+    @Test
+    public void getAsString_Boolean() {
+        helper.setProperty(KnownProperties.TEST_BOOLEAN, true);
+        assertEquals("true", helper.getAsString(KnownProperties.TEST_BOOLEAN));
+    }
+
+    @Test
+    public void getAsString_MigrateDataType() {
+        helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE, new MigrateDataType("5%0%1"));
+        assertEquals("5%0%1", helper.getAsString(KnownProperties.TEST_MIGRATE_TYPE));
+    }
+
+    @Test
+    public void getAsString_MigrateDataTypeList() {
+        helper.setProperty(KnownProperties.TEST_MIGRATE_TYPE_LIST, Arrays.asList(new MigrateDataType("0"), new MigrateDataType("5%0%1")));
+        assertEquals("0,5%0%1", helper.getAsString(KnownProperties.TEST_MIGRATE_TYPE_LIST));
+    }
+
+    @Test
+    public void getAsString_valueNotSet_string() {
+        assertEquals("",helper.getAsString(KnownProperties.TEST_STRING_NO_DEFAULT));
+    }
+
+    @Test
+    public void getAsString_valueNotSet_list() {
+        assertEquals("",helper.getAsString(KnownProperties.TEST_MIGRATE_TYPE_LIST));
+    }
+
+    @Test
+    public void getAsString_nullArgument() {
+        assertNull(helper.getAsString(null));
+    }
+
+    @Test
+    public void getAsString_nullUnhanldedType() {
+        helper.setProperty(KnownProperties.TEST_UNHANDLED_TYPE, "abcd");
+        assertEquals("",helper.getAsString(KnownProperties.TEST_UNHANDLED_TYPE));
+    }
+
+    @Test
+    public void getInstance() {
+        SparkConf sc = new SparkConf();
+        PropertyHelper helper = PropertyHelper.getInstance(sc);
+        assertNotNull(helper);
+    }
+
+    @Test
+    public void initializeSparkConf_null() {
+        Exception e = assertThrows(IllegalArgumentException.class,  () -> {
+            helper.initializeSparkConf(null);
+        });
+        assertTrue(e.getMessage().contains("SparkConf cannot be null"));
+    }
+
+    @Test
+    public void loadSparkConf_missingRequired() {
+        SparkConf sc = new SparkConf();
+        helper.initializeSparkConf(sc);
+        assertFalse(helper.isSparkConfFullyLoaded());
+    }
+
+    @Test
+    public void loadSparkConf_withRequired() {
+        setValidSparkConf();
+        helper.initializeSparkConf(validSparkConf);
+        assertTrue(helper.isSparkConfFullyLoaded());
+    }
+
+    @Test
+    public void loadSparkConf_withRequiredAndAllTypes() {
+        setValidSparkConf();
+        validSparkConf.set(KnownProperties.TEST_STRING, "local");
+        validSparkConf.set(KnownProperties.TEST_STRING_LIST, "A,B,C");
+        validSparkConf.set(KnownProperties.TEST_NUMBER, "1");
+        validSparkConf.set(KnownProperties.TEST_NUMBER_LIST, "4,5,6");
+        validSparkConf.set(KnownProperties.TEST_BOOLEAN, "true");
+        validSparkConf.set(KnownProperties.TEST_MIGRATE_TYPE, "1");
+        validSparkConf.set(KnownProperties.TEST_MIGRATE_TYPE_LIST, "1,2");
+        helper.initializeSparkConf(validSparkConf);
+        assertTrue(helper.isSparkConfFullyLoaded());
+    }
+
+    @Test
+    public void loadSparkConf_badValue() {
+        setValidSparkConf();
+        validSparkConf.set(KnownProperties.TEST_NUMBER_LIST, "a,b,c");
+        helper.initializeSparkConf(validSparkConf);
+        assertFalse(helper.isSparkConfFullyLoaded());
+    }
+
+    @Test
+    public void loadSparkConf_incompleteSourceTLS() {
+        setValidSparkConf();
+        validSparkConf.set(KnownProperties.ORIGIN_TLS_ENABLED, "true");
+        helper.initializeSparkConf(validSparkConf);
+        assertFalse(helper.isSparkConfFullyLoaded());
+    }
+
+    @Test
+    public void loadSparkConf_incompleteTargetTLS() {
+        setValidSparkConf();
+        validSparkConf.set(KnownProperties.TARGET_TLS_ENABLED, "true");
+        helper.initializeSparkConf(validSparkConf);
+        assertFalse(helper.isSparkConfFullyLoaded());
+    }
+
+
+    @Test
+    public void meetsMinimum_true() {
+        assertTrue(helper.meetsMinimum("a", 100,0));
+    }
+
+    @Test
+    public void meetsMinimum_false() {
+        assertFalse(helper.meetsMinimum("a", 1,100));
+    }
+
+    private void setValidSparkConf() {
+        validSparkConf = new SparkConf();
+        validSparkConf.set(KnownProperties.ORIGIN_CONNECT_HOST, "localhost");
+        validSparkConf.set(KnownProperties.ORIGIN_KEYSPACE_TABLE, "ks.tab1");
+        validSparkConf.set(KnownProperties.ORIGIN_COLUMN_NAMES,"a,b");
+        validSparkConf.set(KnownProperties.ORIGIN_PARTITION_KEY, "a");
+        validSparkConf.set(KnownProperties.ORIGIN_COLUMN_TYPES,"1,2");
+        validSparkConf.set(KnownProperties.TARGET_CONNECT_HOST, "localhost");
+        validSparkConf.set(KnownProperties.TARGET_KEYSPACE_TABLE, "ks.tab1");
+        validSparkConf.set(KnownProperties.TARGET_PRIMARY_KEY, "a");
+    }
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What this PR does**:
PropertyHelper allows an abstraction layer between the application and SparkConf, and KnownProperties documents all these properties in a single place.

**Which issue(s) this PR fixes**:
CDM-13

**Checklist:**
- [X] Automated Tests added/updated
- [ ] Documentation added/updated
- [X] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
