### PR TITLE
Reverts package names to reflect latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ tar -xvzf spark-3.3.1-bin-hadoop3.tgz
 
 # Steps for Data-Migration:
 
-> :warning: Note that Version 4 of the tool is not backward-compatible with .properties files created in previous versions, and that package names have changed.
+> :warning: Note that Version 4 of the tool is not backward-compatible with .properties files created in previous versions, and that package names have changed (refer to the relevant example below)
 
 1. `sparkConf.properties` file needs to be configured as applicable for the environment. Parameter descriptions and defaults are described in the file.
    > A sample Spark conf file configuration can be [found here](./src/resources/sparkConf.properties)
 2. Place the conf file where it can be accessed while running the job via spark-submit.
 3. Run the below job using `spark-submit` command as shown below:
+
+```
+./spark-submit --properties-file sparkConf.properties /
+--master "local[*]" /
+--class datastax.astra.migrate.Migrate cassandra-data-migrator-3.x.x.jar &> logfile_name.txt
+```
 
 ```
 ./spark-submit --properties-file sparkConf.properties /
@@ -40,21 +46,36 @@ tar -xvzf spark-3.3.1-bin-hadoop3.tgz
 Note: 
 - Above command generates a log file `logfile_name.txt` to avoid log output on the console.
 - Add option `--driver-memory 25G --executor-memory 25G` as shown below if the table migrated is large (over 100GB)
+
+```
+./spark-submit --properties-file sparkConf.properties /
+--master "local[*]" --driver-memory 25G --executor-memory 25G /
+--class datastax.astra.migrate.Migrate cassandra-data-migrator-3.x.x.jar &> logfile_name.txt
+```
+
 ```
 ./spark-submit --properties-file sparkConf.properties /
 --master "local[*]" --driver-memory 25G --executor-memory 25G /
 --class datastax.cdm.job.Migrate cassandra-data-migrator-4.x.x.jar &> logfile_name.txt
 ```
 
+
 # Steps for Data-Validation:
 
-- To run the job in Data validation mode, use class option `--class datastax.cdm.job.DiffData` as shown below
+- To run the job in Data validation mode, use class option `--class datastax._.DiffData` as shown below
+
+```
+./spark-submit --properties-file sparkConf.properties /
+--master "local[*]" /
+--class datastax.astra.migrate.DiffData cassandra-data-migrator-3.x.x.jar &> logfile_name.txt
+```
 
 ```
 ./spark-submit --properties-file sparkConf.properties /
 --master "local[*]" /
 --class datastax.cdm.job.DiffData cassandra-data-migrator-4.x.x.jar &> logfile_name.txt
 ```
+
 
 - Validation job will report differences as “ERRORS” in the log file as shown below
 
@@ -80,6 +101,11 @@ Note:
 
 # Migrating specific partition ranges
 - You can also use the tool to migrate specific partition ranges using class option `--class datastax.cdm.job.MigratePartitionsFromFile` as shown below
+```
+./spark-submit --properties-file sparkConf.properties /
+--master "local[*]" /
+--class datastax.astra.migrate.MigratePartitionsFromFile cassandra-data-migrator-3.x.x.jar &> logfile_name.txt
+```
 ```
 ./spark-submit --properties-file sparkConf.properties /
 --master "local[*]" /
@@ -113,7 +139,7 @@ This mode is specifically useful to processes a subset of partition-ranges that 
 1. Clone this repo
 2. Move to the repo folder `cd cassandra-data-migrator`
 3. Run the build `mvn clean package` (Needs Maven 3.8.x)
-4. The fat jar (`cassandra-data-migrator-4.x.x.jar`) file should now be present in the `target` folder
+4. The fat jar (`cassandra-data-migrator-x.x.x.jar`) file should now be present in the `target` folder
 
 # Contributors
 Checkout all our wonderful contributors [here](./CONTRIBUTING.md#contributors).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What this PR does**:

Reverts examples with the old package names (alongside the 4.x examples), at least until a 4.x release.

**Which issue(s) this PR fixes**:

Customers are using the examples in the README (with 4.x package names) and are confused why it's not working with the latest available release (3.x).
