### PR TITLE
CDM-63 Target will default to using origin keyspace & table values if…

### DIFF
--- a/src/main/java/com/datastax/cdm/schema/BaseTable.java
+++ b/src/main/java/com/datastax/cdm/schema/BaseTable.java
@@ -43,7 +43,7 @@ public class BaseTable implements Table {
             keyspaceTableString = propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE);
         }
         if (StringUtils.isBlank(keyspaceTableString)) {
-            throw new RuntimeException("Value for required property " + KnownProperties.ORIGIN_KEYSPACE_TABLE + " now provided!!");
+            throw new RuntimeException("Value for required property " + KnownProperties.ORIGIN_KEYSPACE_TABLE + " not provided!!");
         }
 
         return keyspaceTableString.trim();

--- a/src/main/java/com/datastax/cdm/schema/BaseTable.java
+++ b/src/main/java/com/datastax/cdm/schema/BaseTable.java
@@ -1,27 +1,28 @@
 package com.datastax.cdm.schema;
 
-import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.cdm.data.CqlConversion;
+import com.datastax.cdm.properties.IPropertyHelper;
 import com.datastax.cdm.properties.KnownProperties;
-import com.datastax.cdm.properties.PropertyHelper;
+import com.datastax.oss.driver.api.core.type.DataType;
+import org.apache.commons.lang3.StringUtils;
 
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 public class BaseTable implements Table {
-    protected final PropertyHelper propertyHelper;
+    protected final IPropertyHelper propertyHelper;
     protected final boolean isOrigin;
-
     protected String keyspaceName;
     protected String tableName;
     protected List<String> columnNames;
     protected List<DataType> columnCqlTypes;
     protected List<CqlConversion> cqlConversions;
 
-    public BaseTable(PropertyHelper propertyHelper, boolean isOrigin) {
+    public BaseTable(IPropertyHelper propertyHelper, boolean isOrigin) {
         this.propertyHelper = propertyHelper;
         this.isOrigin = isOrigin;
 
-        String keyspaceTableString = (this.isOrigin ? propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE) : propertyHelper.getString(KnownProperties.TARGET_KEYSPACE_TABLE)).trim();
+        String keyspaceTableString = getKeyspaceTableAsString(propertyHelper, isOrigin);
         if (keyspaceTableString.contains(".")) {
             String[] keyspaceTable = keyspaceTableString.split("\\.");
             this.keyspaceName = keyspaceTable[0];
@@ -32,11 +33,47 @@ public class BaseTable implements Table {
         }
     }
 
-    public String getKeyspaceName() {return this.keyspaceName;}
-    public String getTableName() {return this.tableName;}
-    public String getKeyspaceTable() {return this.keyspaceName + "." + this.tableName;}
-    public List<String> getColumnNames(boolean format) { return this.columnNames; }
-    public List<DataType> getColumnCqlTypes() {return this.columnCqlTypes;}
-    public List<CqlConversion> getConversions() {return this.cqlConversions;}
-    public boolean isOrigin() {return this.isOrigin;}
+    @NotNull
+    private String getKeyspaceTableAsString(IPropertyHelper propertyHelper, boolean isOrigin) {
+        String keyspaceTableString = (isOrigin ? propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE) :
+                propertyHelper.getString(KnownProperties.TARGET_KEYSPACE_TABLE));
+
+        // Use origin keyspaceTable property if target not specified
+        if (!isOrigin && StringUtils.isBlank(keyspaceTableString)) {
+            keyspaceTableString = propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE);
+        }
+        if (StringUtils.isBlank(keyspaceTableString)) {
+            throw new RuntimeException("Value for required property " + KnownProperties.ORIGIN_KEYSPACE_TABLE + " now provided!!");
+        }
+
+        return keyspaceTableString.trim();
+    }
+
+    public String getKeyspaceName() {
+        return this.keyspaceName;
+    }
+
+    public String getTableName() {
+        return this.tableName;
+    }
+
+    public String getKeyspaceTable() {
+        return this.keyspaceName + "." + this.tableName;
+    }
+
+    public List<String> getColumnNames(boolean format) {
+        return this.columnNames;
+    }
+
+    public List<DataType> getColumnCqlTypes() {
+        return this.columnCqlTypes;
+    }
+
+    public List<CqlConversion> getConversions() {
+        return this.cqlConversions;
+    }
+
+    public boolean isOrigin() {
+        return this.isOrigin;
+    }
 }

--- a/src/main/java/com/datastax/cdm/schema/Table.java
+++ b/src/main/java/com/datastax/cdm/schema/Table.java
@@ -1,11 +1,15 @@
 package com.datastax.cdm.schema;
 
 import com.datastax.oss.driver.api.core.type.DataType;
+
 import java.util.List;
 
 public interface Table {
     String getKeyspaceName();
+
     String getTableName();
+
     List<String> getColumnNames(boolean asCql);
+
     List<DataType> getColumnCqlTypes();
 }

--- a/src/test/java/com/datastax/cdm/schema/BaseTableTest.java
+++ b/src/test/java/com/datastax/cdm/schema/BaseTableTest.java
@@ -1,0 +1,50 @@
+package com.datastax.cdm.schema;
+
+import com.datastax.cdm.cql.CommonMocks;
+import com.datastax.cdm.properties.KnownProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+public class BaseTableTest extends CommonMocks {
+    public Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+
+    @BeforeEach
+    public void setup() {
+        defaultClassVariables();
+        commonSetupWithoutDefaultClassVariables();
+    }
+
+    @Test
+    public void useOriginWhenTargetAbsent() {
+        when(propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE)).thenReturn("origin_ks.origin_table");
+        BaseTable bt = new BaseTable(propertyHelper, false);
+
+        assertAll(
+                () -> assertEquals("origin_ks", bt.getKeyspaceName()),
+                () -> assertEquals("origin_table", bt.getTableName())
+        );
+    }
+
+    @Test
+    public void useTargetWhenTargetPresent() {
+        when(propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE)).thenReturn("origin_ks.origin_table");
+        when(propertyHelper.getString(KnownProperties.TARGET_KEYSPACE_TABLE)).thenReturn("target_ks.target_table");
+        BaseTable bt = new BaseTable(propertyHelper, false);
+
+        assertAll(
+                () -> assertEquals("target_ks", bt.getKeyspaceName()),
+                () -> assertEquals("target_table", bt.getTableName())
+        );
+    }
+
+    @Test
+    public void failWhenKsTableAbsent() {
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> new BaseTable(propertyHelper, false));
+        assertTrue(thrown.getMessage().contentEquals("Value for required property " + KnownProperties.ORIGIN_KEYSPACE_TABLE + " now provided!!"));
+    }
+}

--- a/src/test/java/com/datastax/cdm/schema/BaseTableTest.java
+++ b/src/test/java/com/datastax/cdm/schema/BaseTableTest.java
@@ -45,6 +45,6 @@ public class BaseTableTest extends CommonMocks {
     @Test
     public void failWhenKsTableAbsent() {
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> new BaseTable(propertyHelper, false));
-        assertTrue(thrown.getMessage().contentEquals("Value for required property " + KnownProperties.ORIGIN_KEYSPACE_TABLE + " now provided!!"));
+        assertTrue(thrown.getMessage().contentEquals("Value for required property " + KnownProperties.ORIGIN_KEYSPACE_TABLE + " not provided!!"));
     }
 }


### PR DESCRIPTION
**What this PR does**: Default to using `origin` `keyspace` & `table` values if `target` values not provided.


**Which issue(s) this PR fixes**:
Fixes # CDM-63

**Checklist:**
- [x] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
