### PR TITLE
[CDM-84] Improve usage of Apache Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,13 @@
           <artifactId>log4j-slf4j-impl</artifactId>
         </exclusion>
       </exclusions>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.main.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
@@ -66,6 +68,7 @@
           <artifactId>apache-log4j-extras</artifactId>
         </exclusion>
       </exclusions>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.datastax.spark</groupId>

--- a/src/main/scala/com/datastax/cdm/job/BaseJob.scala
+++ b/src/main/scala/com/datastax/cdm/job/BaseJob.scala
@@ -77,7 +77,7 @@ abstract class BaseJob[T: ClassTag] extends App {
     this.parts = getParts(numSplits)
     this.slices = sContext.parallelize(parts.asScala.toSeq, parts.size);
     abstractLogger.info("PARAM Calculated -- Total Partitions: " + parts.size())
-    abstractLogger.info("Spark parallelize created : " + slices.count() + " slices!");
+    abstractLogger.info("Spark parallelize created : " + slices.getNumPartitions + " slices!");
 
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What this PR does**:
* Given that CDM requires users to download Apache Spark separately and submit the job, it is not necessary to bundle spark classes and shaded jars. This reduces the size of the shaded jar around 30MB.
* Currently, unnecessary tasks (10,000 tasks for default num parts) are created just to log the number of partitions. Use `getNumPartitions` instead. (Alternatively, we can remove the log line altogether since it does not add any value at all.)

**Which issue(s) this PR fixes**:
Fixes CDM-84

**Checklist:**
- [ ] Automated Tests added/updated (not applicable)
- [ ] Documentation added/updated (not applicable)
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
