### PR TITLE
CDM-92: Fix NPE issue with target counter tables with null fields

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
-## [4.1.3] - 2023-07-06
+## [4.1.4] - 2023-08-16
+- In rare edge situations, counter tables with existing data in Target can have null values on target. This release will handle null values in Target counter table transparently.
+
+## [4.1.3] - 2023-08-14
 - Counter table columns will usually have zeros to begin with, but in rare edge situations, they can have null values. This release will handle null values in counter table transparently.
 
 ## [4.1.2] - 2023-07-06

--- a/SIT/smoke/04_counters/cdm.fixData.assert
+++ b/SIT/smoke/04_counters/cdm.fixData.assert
@@ -1,7 +1,7 @@
-Read Record Count: 6
+Read Record Count: 7
 Mismatch Record Count: 2
 Corrected Mismatch Record Count: 2
 Missing Record Count: 1
 Corrected Missing Record Count: 0
-Valid Record Count: 3
+Valid Record Count: 4
 Skipped Record Count: 0

--- a/SIT/smoke/04_counters/cdm.fixForce.assert
+++ b/SIT/smoke/04_counters/cdm.fixForce.assert
@@ -1,7 +1,7 @@
-Read Record Count: 6
+Read Record Count: 7
 Mismatch Record Count: 0
 Corrected Mismatch Record Count: 0
 Missing Record Count: 1
 Corrected Missing Record Count: 1
-Valid Record Count: 5
+Valid Record Count: 6
 Skipped Record Count: 0

--- a/SIT/smoke/04_counters/cdm.migrateData.assert
+++ b/SIT/smoke/04_counters/cdm.migrateData.assert
@@ -1,4 +1,4 @@
-Read Record Count: 6
+Read Record Count: 7
 Skipped Record Count: 0
-Write Record Count: 6
+Write Record Count: 7
 Error Record Count: 0

--- a/SIT/smoke/04_counters/cdm.validateData.assert
+++ b/SIT/smoke/04_counters/cdm.validateData.assert
@@ -1,7 +1,7 @@
-Read Record Count: 6
+Read Record Count: 7
 Mismatch Record Count: 0
 Corrected Mismatch Record Count: 0
 Missing Record Count: 0
 Corrected Missing Record Count: 0
-Valid Record Count: 6
+Valid Record Count: 7
 Skipped Record Count: 0

--- a/SIT/smoke/04_counters/expected.out
+++ b/SIT/smoke/04_counters/expected.out
@@ -6,6 +6,7 @@
  record2 |    11 |    20
  record6 |   500 |  null
  record1 |     1 |     2
+ record7 |     1 |     2
  record4 | 10000 | 20001
 
-(6 rows)
+(7 rows)

--- a/SIT/smoke/04_counters/setup.cql
+++ b/SIT/smoke/04_counters/setup.cql
@@ -11,4 +11,6 @@ UPDATE origin.smoke_counters set col1=col1+500 where key='record6';
 DROP TABLE IF EXISTS target.smoke_counters;
 CREATE TABLE target.smoke_counters(key text,col1 counter,col2 counter, PRIMARY KEY (key));
 
+UPDATE target.smoke_counters set col1=col1+1 where key='record1';
+
 SELECT * FROM origin.smoke_counters;

--- a/SIT/smoke/04_counters/setup.cql
+++ b/SIT/smoke/04_counters/setup.cql
@@ -7,10 +7,11 @@ UPDATE origin.smoke_counters set col1=col1+1000, col2=col2+2000 where key='recor
 UPDATE origin.smoke_counters set col1=col1+10000, col2=col2+20000 where key='record4';
 UPDATE origin.smoke_counters set col1=col1+500, col2=col2+500 where key='record5';
 UPDATE origin.smoke_counters set col1=col1+500 where key='record6';
+UPDATE origin.smoke_counters set col1=col1+1, col2=col2+2 where key='record7';
 
 DROP TABLE IF EXISTS target.smoke_counters;
 CREATE TABLE target.smoke_counters(key text,col1 counter,col2 counter, PRIMARY KEY (key));
 
-UPDATE target.smoke_counters set col1=col1+1 where key='record1';
+UPDATE target.smoke_counters set col1=col1+1 where key='record7';
 
 SELECT * FROM origin.smoke_counters;

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <connection>scm:git:git@github.com:datastax/cassandra-data-migrator.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/cassandra-data-migrator.git</developerConnection>
     <url>https://github.com/datastax/cassandra-data-migrator</url>
-    <tag>@{project.version}</tag>
+    <tag>@{version}</tag>
   </scm>
 
   <build>

--- a/src/main/java/com/datastax/cdm/cql/statement/TargetUpdateStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/TargetUpdateStatement.java
@@ -42,37 +42,37 @@ public class TargetUpdateStatement extends TargetUpsertStatement {
             boundStatement = boundStatement.set(currentBindIndex++, writeTime, Long.class);
         }
 
-        Object bindValueOrg = null;
-        Object bindValueDest = null;
+        Object bindValueOrigin = null;
+        Object bindValueTarget = null;
         for (int targetIndex : columnIndexesToBind) {
             int originIndex = cqlTable.getCorrespondingIndex(targetIndex);
 
             try {
                 if (usingCounter && counterIndexes.contains(targetIndex)) {
-                    bindValueOrg = cqlTable.getOtherCqlTable().getData(originIndex, originRow);
-                    if (null == bindValueOrg) {
+                    bindValueOrigin = cqlTable.getOtherCqlTable().getData(originIndex, originRow);
+                    if (null == bindValueOrigin) {
                         currentBindIndex++;
                         continue;
                     }
-                    bindValueDest = (null == targetRow ? 0L : cqlTable.getData(targetIndex, targetRow));
-                    bindValueDest = ((Long) bindValueOrg - (null == bindValueDest ? 0L : (Long) bindValueDest));
+                    bindValueTarget = (null == targetRow ? 0L : cqlTable.getData(targetIndex, targetRow));
+                    bindValueTarget = ((Long) bindValueOrigin - (null == bindValueTarget ? 0L : (Long) bindValueTarget));
                 }
                 else if (targetIndex== explodeMapKeyIndex) {
-                    bindValueDest = explodeMapKey;
+                    bindValueTarget = explodeMapKey;
                 }
                 else if (targetIndex== explodeMapValueIndex) {
-                    bindValueDest = explodeMapValue;
+                    bindValueTarget = explodeMapValue;
                 } else {
                     if (originIndex < 0)
                         // we don't have data to bind for this column; continue to the next targetIndex
                         continue;
-                    bindValueDest = cqlTable.getOtherCqlTable().getAndConvertData(originIndex, originRow);
+                    bindValueTarget = cqlTable.getOtherCqlTable().getAndConvertData(originIndex, originRow);
                 }
 
-                boundStatement = boundStatement.set(currentBindIndex++, bindValueDest, cqlTable.getBindClass(targetIndex));
+                boundStatement = boundStatement.set(currentBindIndex++, bindValueTarget, cqlTable.getBindClass(targetIndex));
             }
             catch (Exception e) {
-                logger.error("Error trying to bind value:" + bindValueDest + " to column:" +
+                logger.error("Error trying to bind value:" + bindValueTarget + " to column:" +
                         targetColumnNames.get(targetIndex) + " of targetDataType:" + targetColumnTypes.get(targetIndex) + "/"
                         + cqlTable.getBindClass(targetIndex).getName() + " at column index:" + targetIndex);
                 throw e;

--- a/src/main/java/com/datastax/cdm/cql/statement/TargetUpdateStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/TargetUpdateStatement.java
@@ -42,20 +42,20 @@ public class TargetUpdateStatement extends TargetUpsertStatement {
             boundStatement = boundStatement.set(currentBindIndex++, writeTime, Long.class);
         }
 
-        Object bindValueOrigin = null;
+        Object originValue, targetValue;
         Object bindValueTarget = null;
         for (int targetIndex : columnIndexesToBind) {
             int originIndex = cqlTable.getCorrespondingIndex(targetIndex);
 
             try {
                 if (usingCounter && counterIndexes.contains(targetIndex)) {
-                    bindValueOrigin = cqlTable.getOtherCqlTable().getData(originIndex, originRow);
-                    if (null == bindValueOrigin) {
+                    originValue = cqlTable.getOtherCqlTable().getData(originIndex, originRow);
+                    if (null == originValue) {
                         currentBindIndex++;
                         continue;
                     }
-                    bindValueTarget = (null == targetRow ? 0L : cqlTable.getData(targetIndex, targetRow));
-                    bindValueTarget = ((Long) bindValueOrigin - (null == bindValueTarget ? 0L : (Long) bindValueTarget));
+                    targetValue = (null == targetRow ? 0L : cqlTable.getData(targetIndex, targetRow));
+                    bindValueTarget = ((Long) originValue - (null == targetValue ? 0L : (Long) targetValue));
                 }
                 else if (targetIndex== explodeMapKeyIndex) {
                     bindValueTarget = explodeMapKey;
@@ -70,8 +70,7 @@ public class TargetUpdateStatement extends TargetUpsertStatement {
                 }
 
                 boundStatement = boundStatement.set(currentBindIndex++, bindValueTarget, cqlTable.getBindClass(targetIndex));
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 logger.error("Error trying to bind value:" + bindValueTarget + " to column:" +
                         targetColumnNames.get(targetIndex) + " of targetDataType:" + targetColumnTypes.get(targetIndex) + "/"
                         + cqlTable.getBindClass(targetIndex).getName() + " at column index:" + targetIndex);


### PR DESCRIPTION
**What this PR does**: Fixes NPE issue when there are null values in target counter tables.

**Which issue(s) this PR fixes**:
Fixes #189 

**Checklist:**
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
