### PR TITLE
Use latest Maven 3 patch version for Docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,11 @@ RUN apt-get update && apt-get install -y openssh-server vim python3 --no-install
     rm -rf /var/lib/apt/lists/*  && \
     service ssh start
 
+COPY scripts/get-latest-maven-version.sh ./get-latest-maven-version.sh
+RUN chmod +x ./get-latest-maven-version.sh
+
 # Copy CDM jar & template files
-ARG MAVEN_VERSION=3.9.3
+ARG MAVEN_VERSION=$(./get-latest-maven-version.sh)
 ARG USER_HOME_DIR="/root"
 ARG BASE_URL=https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 ENV MAVEN_HOME /usr/share/maven

--- a/scripts/get-latest-maven-version.sh
+++ b/scripts/get-latest-maven-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+MAVEN_BASE_VERSION=3.9
+MAVEN_REPO_URL="https://archive.apache.org/dist/maven/maven-3/"
+
+curl -sSL ${MAVEN_REPO_URL} | \
+  grep -o "${MAVEN_BASE_VERSION}\.[0-9]*\/" | \
+  sort -V | \
+  tail -n1 | \
+  sed 's/\///'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

### What this PR does
Automatically fetch & use the latest Maven 3 patch version for Docker builds/publish workflow

### Design Alternatives Considered & Rejected
We could have simply modified the [`BASE_URL` within the `Dockerfile`](https://github.com/datastax/cassandra-data-migrator/blob/main/Dockerfile#L23) to https://archive.apache.org/dist/maven/maven-3/, but it would be more prudent to automatically fetch the latest patch version in the maven `3.9` series and use it here so we don't have to touch this script until at a point when we decide to switch using the next Maven major/minor version.


**Which issue(s) this PR fixes**:
Fixes #202 

**Checklist:**
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
