### PR TITLE
Fix for issue 218 writetime and TTL are not preserved

### DIFF
--- a/src/main/java/com/datastax/cdm/feature/WritetimeTTL.java
+++ b/src/main/java/com/datastax/cdm/feature/WritetimeTTL.java
@@ -62,9 +62,8 @@ public class WritetimeTTL extends AbstractFeature  {
 
         isValid = validateProperties();
         isEnabled = isValid &&
-                ((null != ttlNames && !ttlNames.isEmpty())
-                || (null != writetimeNames && !writetimeNames.isEmpty())
-                || customWritetime > 0);
+                (this.autoWritetimeNames || this.autoTTLNames
+                        || customWritetime > 0);
 
         isLoaded = true;
         return isValid;


### PR DESCRIPTION
Suggested fix for the following issue:
https://github.com/datastax/cassandra-data-migrator/issues/218 writetime and TTL are not preserved if columns are not explicitly configured in cdm.properties

<!--  Thanks for sending a pull request!  -->

**What this PR does**:
Fix issue 218: writetime and TTL are not preserved if columns are not explicitly configured in cdm.properties

**Which issue(s) this PR fixes**:
Fixes #218

**Checklist:**
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
