### PR TITLE
Integration test fixes and ttl/writetime auto flag default changes to false

### DIFF
--- a/SIT/environment.sh
+++ b/SIT/environment.sh
@@ -81,7 +81,7 @@ _testDockerNetwork() {
 }
 
 _testDockerCassandra() {
-  dockerPs=$(docker ps -a | awk '{if ($NF == "'${DOCKER_CASS}'") {print "yes"}}')
+  dockerPs=$(docker ps | awk '{if ($NF == "'${DOCKER_CASS}'") {print "yes"}}')
   if [ "$dockerPs" != "yes" ]; then
     echo "no"
     return
@@ -154,7 +154,7 @@ _dropKeyspaces() {
 }
 
 _testDockerCDM() {
-  dockerPs=$(docker ps -a | awk '{if ($NF == "'${DOCKER_CDM}'") {print "yes"}}')
+  dockerPs=$(docker ps | awk '{if ($NF == "'${DOCKER_CDM}'") {print "yes"}}')
   if [ "$dockerPs" != "yes" ]; then
     echo "no"
   else

--- a/SIT/test.sh
+++ b/SIT/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 _usage() {
   cat <<EOF
 
@@ -36,11 +35,11 @@ fi
 
 _captureOutput() {
   _info "Copying ${DOCKER_CDM}:/${testDir} into ${testDir}/output"
-  docker cp ${DOCKER_CDM}:/${testDir} ${testDir}/output
-  _info "Moving ${testDir}/output/$(basename ${testDir})/*.out TO ${testDir}/output"
-  mv ${testDir}/output/$(basename ${testDir})/*.out ${testDir}/output
-  _info "Moving ${testDir}/output/$(basename ${testDir})/*.err TO ${testDir}/output"
-  mv ${testDir}/output/$(basename ${testDir})/*.err ${testDir}/output
+  docker cp ${DOCKER_CDM}:/${testDir} ${testDir}/output/
+  _info "Moving ${testDir}/output/$(basename ${testDir})/output/*.out TO ${testDir}/output"
+  mv ${testDir}/output/$(basename ${testDir})/output/*.out ${testDir}/output/
+  _info "Moving ${testDir}/output/$(basename ${testDir})/output/*.err TO ${testDir}/output/"
+  mv ${testDir}/output/$(basename ${testDir})/output/*.err ${testDir}/output/
   _info "Removing ${testDir}/output/$(basename ${testDir})"
   rm -rf ${testDir}/output/$(basename ${testDir})
 }
@@ -124,7 +123,7 @@ errors=0
 for testDir in $(ls -d ${PHASE}/*); do
   export testDir
   _info ${testDir} Executing test
-  docker exec ${DOCKER_CDM} bash -e $testDir/execute.sh /$testDir > $testDir/output/execute.out 2>$testDir/output/execute.err
+  docker exec ${DOCKER_CDM} bash -e -c "$testDir/execute.sh /$testDir > $testDir/output/execute.out 2>$testDir/output/execute.err"
   if [ $? -ne 0 ]; then
     _error "${testDir}/execute.sh failed, see $testDir/output/execute.out and $testDir/output/execute.err"
     echo "=-=-=-=-=-=-=-=-=-= Directory Listing =-=-=-=-=-=-=-=-=-=-"

--- a/src/main/java/com/datastax/cdm/properties/KnownProperties.java
+++ b/src/main/java/com/datastax/cdm/properties/KnownProperties.java
@@ -85,10 +85,10 @@ public class KnownProperties {
         required.add(ORIGIN_KEYSPACE_TABLE);
            types.put(ORIGIN_TTL_NAMES, PropertyType.STRING_LIST);
            types.put(ORIGIN_TTL_AUTO, PropertyType.BOOLEAN);
-        defaults.put(ORIGIN_TTL_AUTO, "true");
+        defaults.put(ORIGIN_TTL_AUTO, "false");
            types.put(ORIGIN_WRITETIME_NAMES, PropertyType.STRING_LIST);
            types.put(ORIGIN_WRITETIME_AUTO, PropertyType.BOOLEAN);
-        defaults.put(ORIGIN_WRITETIME_AUTO, "true");
+        defaults.put(ORIGIN_WRITETIME_AUTO, "false");
            types.put(ORIGIN_COLUMN_NAMES_TO_TARGET, PropertyType.STRING_LIST);
     }
 


### PR DESCRIPTION
In two places in environment.sh we do a check to see if a container is up and running, but we user docker ps -a, which lists all containers (if those that are not running). I encountered this issue while trying to run the integration tests locally:

```
++ _testDockerCDM_Directory
++ docker exec cdm-sit-cdm ls /local/cassandra-data-migrator.jar
++ rtn=1
++ '[' 1 -eq 0 ']'
++ echo no
+ '[' no '!=' yes ']'
+ _createDockerCDM_Directory
+ docker exec cdm-sit-cdm mkdir -p /local
Error response from daemon: Container 2ba95ecae35c69594c57fdfe41d872df4b1dac98a73cded529c47087c6617466 is not running
make: *** [env_setup] Error 1
```

**Checklist:**
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
