### PR TITLE
Fix tokenrange document

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Each line above represents a partition-range (`min,max`). Alternatively, you can
 ```
 ./spark-submit --properties-file cdm.properties \
  --conf spark.cdm.schema.origin.keyspaceTable="<keyspacename>.<tablename>" \
- --conf spark.cdm.tokenRange.partitionFile="/<path-to-file>/<csv-input-filename>" \
+ --conf spark.cdm.tokenrange.partitionFile="/<path-to-file>/<csv-input-filename>" \
  --master "local[*]" --driver-memory 25G --executor-memory 25G \
  --class com.datastax.cdm.job.<Migrate|DiffData> cassandra-data-migrator-4.x.x.jar &> logfile_name_$(date +%Y%m%d_%H_%M).txt
 ```

--- a/src/resources/cdm-detailed.properties
+++ b/src/resources/cdm-detailed.properties
@@ -152,7 +152,7 @@ spark.cdm.schema.origin.keyspaceTable                keyspace_name.table_name
 #                           counter gets DELETEd. Should the .missing record be re-inserted before
 #                           the DELETE gets tombstoned, the counter will zombie back to life, and the
 #                           counter will become 5323+5323 = 10646. 
-#  spark.cdm.tokenRange
+#  spark.cdm.tokenrange
 #   .partitionFile        : Default is "./<keyspace>.<tablename>_partitions.csv". Note, this file is used as
 #                           input as well as output when applicable. If the file exists, only the partition ranges
 #                           in this file will be Migrated or Validated. Similarly, if exceptions occur during


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What this PR does**:

Modifies the document associated with tokenrange. 

The tokenrange option in `--conf spark.cdm.tokenrange.partitionFile="/<path-to-file>/<csv-input-filename>"` must be in lowercase.