### PR TITLE
Use origin ks/tbl when target properties is not specified

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Release Notes
+## [4.3.4] - 2024-07-31
+- Use `spark.cdm.schema.origin.keyspaceTable` when `spark.cdm.schema.target.keyspaceTable` is missing. Fixes [bug introduced in prior version](https://github.com/datastax/cassandra-data-migrator/issues/284).
+
 ## [4.3.3] - 2024-07-22
 - Removed deprecated functionality related to processing token-ranges via partition-file
 - Upgraded Spark Cassandra Connector (SCC) version to 3.5.1.
@@ -8,7 +11,7 @@
 - Removed deprecated functionality related to retry
 
 ## [4.3.1] - 2024-07-19
-- Fixed a validation run [bug] (https://github.com/datastax/cassandra-data-migrator/issues/266) that sometimes did not report a failed token-range
+- Fixed a validation run [bug](https://github.com/datastax/cassandra-data-migrator/issues/266) that sometimes did not report a failed token-range
 - Removed deprecated MigrateRowsFromFile job
 
 ## [4.3.0] - 2024-07-18

--- a/src/main/scala/com/datastax/cdm/job/BasePartitionJob.scala
+++ b/src/main/scala/com/datastax/cdm/job/BasePartitionJob.scala
@@ -25,9 +25,10 @@ abstract class BasePartitionJob extends BaseJob[SplitPartitions.Partition] {
 
   override def getParts(pieces: Int): util.Collection[SplitPartitions.Partition] = {
     var keyspaceTable: Option[String] = Option(propertyHelper.getString(KnownProperties.TARGET_KEYSPACE_TABLE))
+      .filter(_.nonEmpty)
       .orElse(Option(propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE)))
       
-    val keyspaceTableValue: String = keyspaceTable.getOrElse {
+    var keyspaceTableValue: String = keyspaceTable.getOrElse {
       throw new RuntimeException("Both " + KnownProperties.TARGET_KEYSPACE_TABLE + " and " 
         + KnownProperties.ORIGIN_KEYSPACE_TABLE + " properties are missing.")
     }

--- a/src/main/scala/com/datastax/cdm/job/BasePartitionJob.scala
+++ b/src/main/scala/com/datastax/cdm/job/BasePartitionJob.scala
@@ -24,10 +24,16 @@ abstract class BasePartitionJob extends BaseJob[SplitPartitions.Partition] {
   var trackRunFeature: TrackRun = _
 
   override def getParts(pieces: Int): util.Collection[SplitPartitions.Partition] = {
-    var keyspaceTable = propertyHelper.getString(KnownProperties.TARGET_KEYSPACE_TABLE)
+    var keyspaceTable: Option[String] = Option(propertyHelper.getString(KnownProperties.TARGET_KEYSPACE_TABLE))
+      .orElse(Option(propertyHelper.getString(KnownProperties.ORIGIN_KEYSPACE_TABLE)))
+      
+    val keyspaceTableValue: String = keyspaceTable.getOrElse {
+      throw new RuntimeException("Both " + KnownProperties.TARGET_KEYSPACE_TABLE + " and " 
+        + KnownProperties.ORIGIN_KEYSPACE_TABLE + " properties are missing.")
+    }
   
     if (trackRun) {
-      trackRunFeature = targetConnection.withSessionDo(targetSession => new TrackRun(targetSession, keyspaceTable))
+      trackRunFeature = targetConnection.withSessionDo(targetSession => new TrackRun(targetSession, keyspaceTableValue))
     }
     
     if (prevRunId != 0) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What this PR does**: Filter out empty values for target ks/tbl properties when not provided and uses origin values.

**Which issue(s) this PR fixes**:
Fixes #284 

**Checklist:**
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
