### PR TITLE
Implemented customTTL feature

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Release Notes
+## [4.3.7] - 2024-09-03
+- Added property `spark.cdm.transform.custom.ttl` to allow a custom constant value to be set for TTL instead of using the values from `origin` rows.
+
 ## [4.3.6] - 2024-08-29
 - Added `overwrite` option to conditionally check or skip `Validation` when it has a non-null value in `target` for the `spark.cdm.feature.extractJson` feature.
 

--- a/src/main/java/com/datastax/cdm/properties/KnownProperties.java
+++ b/src/main/java/com/datastax/cdm/properties/KnownProperties.java
@@ -161,6 +161,7 @@ public class KnownProperties {
 	public static final String TRANSFORM_REPLACE_MISSING_TS = "spark.cdm.transform.missing.key.ts.replace.value";
 	public static final String TRANSFORM_CUSTOM_WRITETIME = "spark.cdm.transform.custom.writetime";
 	public static final String TRANSFORM_CUSTOM_WRITETIME_INCREMENT = "spark.cdm.transform.custom.writetime.incrementBy";
+	public static final String TRANSFORM_CUSTOM_TTL = "spark.cdm.transform.custom.ttl";
 	public static final String TRANSFORM_CODECS = "spark.cdm.transform.codecs";
 	public static final String TRANSFORM_CODECS_TIMESTAMP_STRING_FORMAT = "spark.cdm.transform.codecs.timestamp.string.format";
 	public static final String TRANSFORM_CODECS_TIMESTAMP_STRING_FORMAT_ZONE = "spark.cdm.transform.codecs.timestamp.string.zone";
@@ -170,6 +171,8 @@ public class KnownProperties {
 		types.put(TRANSFORM_REPLACE_MISSING_TS, PropertyType.NUMBER);
 		types.put(TRANSFORM_CUSTOM_WRITETIME, PropertyType.NUMBER);
 		defaults.put(TRANSFORM_CUSTOM_WRITETIME, "0");
+		types.put(TRANSFORM_CUSTOM_TTL, PropertyType.NUMBER);
+		defaults.put(TRANSFORM_CUSTOM_TTL, "0");
 		types.put(TRANSFORM_CUSTOM_WRITETIME_INCREMENT, PropertyType.NUMBER);
 		defaults.put(TRANSFORM_CUSTOM_WRITETIME_INCREMENT, "0");
 		types.put(TRANSFORM_CODECS, PropertyType.STRING_LIST);

--- a/src/resources/cdm-detailed.properties
+++ b/src/resources/cdm-detailed.properties
@@ -74,6 +74,9 @@ spark.cdm.connect.target.password      cassandra
 #                           all origin columns that can have TTL set (which excludes partition key,
 #                           clustering key, collections and UDTs). When false, and .names is not set, the target 
 #                           record will have the TTL determined by the target table configuration.
+#
+#                           *** Note spark.cdm.transform.custom.ttl overrides this setting ***
+#
 #          .names         : Default is empty, meaning they will be determined automatically if that is set
 #                           (see above). Specify a subset of eligible columns that are used to calculate
 #                           the TTL of the target record.
@@ -247,6 +250,12 @@ spark.cdm.perfops.ratelimit.target                20000
 #                                    and subsequent UPSERTs would add duplicates to the list. Future versions
 #                                    of CDM may tombstone the previous list, but for now this solution is
 #                                    viable and, crucially, more performant.
+#      .ttl                          Default is 0 (no expiry). Time-to-live value in seconds to use as the
+#                                    TTL for the target record. This is useful when the TTL of the record in
+#                                    Origin cannot be determined (such as the only non-key columns are 
+#                                    collections) OR is a new TTL needs to be set during migration. This 
+#                                    parameter allows a crude constant value to be used in its place, and 
+#                                    overrides .schema.origin.column.ttl.names
 #   .codecs                          Default is empty. A comma-separated list of additional codecs to
 #                                    enable. Current codecs are:
 #                                        INT_STRING                : int stored in a String
@@ -273,6 +282,7 @@ spark.cdm.perfops.ratelimit.target                20000
 #spark.cdm.transform.missing.key.ts.replace.value      1685577600000
 #spark.cdm.transform.custom.writetime                  0
 #spark.cdm.transform.custom.writetime.incrementBy      0
+#spark.cdm.transform.custom.ttl                        0
 #spark.cdm.transform.codecs
 #spark.cdm.transform.codecs.timestamp.string.format    yyyyMMddHHmmss
 #spark.cdm.transform.codecs.timestamp.string.zone      UTC

--- a/src/test/java/com/datastax/cdm/feature/TTLAndWritetimeTest.java
+++ b/src/test/java/com/datastax/cdm/feature/TTLAndWritetimeTest.java
@@ -34,6 +34,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
 
     WritetimeTTL feature;
     Long customWritetime = 123456789L;
+    Long customTTL = 1000L;
     Long filterMin = 100000000L;
     Long filterMax = 200000000L;
     String writetimeColumnName = "writetime_col";
@@ -69,6 +70,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
             String argument = invocation.getArgument(0);
             return originValueColumns.contains(argument);
         });
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(customTTL);
     }
 
 
@@ -83,6 +85,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
         assertAll(
                 () -> assertTrue(feature.isEnabled(), "enabled"),
                 () -> assertEquals(customWritetime, feature.getCustomWritetime(), "customWritetime"),
+                () -> assertEquals(customTTL, feature.getCustomTTL(), "customTTL"),
                 () -> assertTrue(feature.hasWriteTimestampFilter(), "hasWriteTimestampFilter"),
                 () -> assertTrue(feature.hasWritetimeColumns(), "hasWritetimeColumns with custom writetime"),
                 () -> assertEquals(customWritetime, feature.getCustomWritetime(), "customWritetime is set"),
@@ -113,6 +116,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
         when(propertyHelper.getLong(KnownProperties.FILTER_WRITETS_MAX)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_TTL_NAMES)).thenReturn(null);
         when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_WRITETIME)).thenReturn(null);
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_WRITETIME_NAMES)).thenReturn(null);
         when(propertyHelper.getBoolean(KnownProperties.ORIGIN_WRITETIME_AUTO)).thenReturn(Boolean.FALSE);
         when(propertyHelper.getBoolean(KnownProperties.ORIGIN_TTL_AUTO)).thenReturn(Boolean.FALSE);
@@ -135,6 +139,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
         when(propertyHelper.getLong(KnownProperties.FILTER_WRITETS_MAX)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_TTL_NAMES)).thenReturn(null);
         when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_WRITETIME)).thenReturn(null);
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_WRITETIME_NAMES)).thenReturn(null);
         when(propertyHelper.getBoolean(KnownProperties.ORIGIN_WRITETIME_AUTO)).thenReturn(Boolean.TRUE);
         when(propertyHelper.getBoolean(KnownProperties.ORIGIN_TTL_AUTO)).thenReturn(Boolean.FALSE);
@@ -174,6 +179,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
     @Test
     public void smoke_writetimeWithoutTTL() {
         when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_WRITETIME)).thenReturn(0L);
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_TTL_NAMES)).thenReturn(null);
         when(propertyHelper.getLong(KnownProperties.FILTER_WRITETS_MIN)).thenReturn(filterMin);
         when(propertyHelper.getLong(KnownProperties.FILTER_WRITETS_MAX)).thenReturn(filterMax);
@@ -225,6 +231,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
     @Test
     public void smoke_autoWritetime_noCustomWritetime() {
         when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_WRITETIME)).thenReturn(0L);
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_WRITETIME_NAMES)).thenReturn(null);
         when(propertyHelper.getBoolean(KnownProperties.ORIGIN_WRITETIME_AUTO)).thenReturn(true);
         when(propertyHelper.getLong(KnownProperties.FILTER_WRITETS_MIN)).thenReturn(null);
@@ -244,6 +251,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
     @Test
     public void smoke_autoWritetime_CustomWritetime() {
         when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_WRITETIME)).thenReturn(100L);
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(null);
         when(propertyHelper.getStringList(KnownProperties.ORIGIN_WRITETIME_NAMES)).thenReturn(null);
         when(propertyHelper.getBoolean(KnownProperties.ORIGIN_WRITETIME_AUTO)).thenReturn(true);
         when(propertyHelper.getLong(KnownProperties.FILTER_WRITETS_MIN)).thenReturn(null);
@@ -373,6 +381,7 @@ public class TTLAndWritetimeTest extends CommonMocks {
 
     @Test
     public void getLargestTTLTest() {
+        when(propertyHelper.getLong(KnownProperties.TRANSFORM_CUSTOM_TTL)).thenReturn(null);
         when(originTable.indexOf("TTL("+ttlColumnName+")")).thenReturn(100);
         when(originRow.getInt(eq(100))).thenReturn(30);
         when(originTable.indexOf("TTL("+writetimeTTLColumnName+")")).thenReturn(101);


### PR DESCRIPTION
**What this PR does**: Implemented property `spark.cdm.transform.custom.ttl` to allow a custom constant value to be set for TTL instead of using the values from origin rows.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist:**
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
