### PR TITLE
Replace dateOf function with toTimestamp as it is fully removed in C* 5.0.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## [5.2.2] - 2025-04-02
+- Replaced deprecated (not supported in Cassandra 5.0.3+) function `dateof()` with `totimestamp()`
+
 ## [5.2.1] - 2025-03-10
 - Implemented [`column.skip`](https://github.com/datastax/cassandra-data-migrator/blob/main/src/resources/cdm-detailed.properties#L97) feature
 

--- a/src/main/java/com/datastax/cdm/cql/statement/TargetUpsertRunDetailsStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/TargetUpsertRunDetailsStatement.java
@@ -76,15 +76,15 @@ public class TargetUpsertRunDetailsStatement {
         }
 
         boundInitInfoStatement = bindStatement("INSERT INTO " + cdmKsTabInfo
-                + " (table_name, run_id, run_type, prev_run_id, start_time, status) VALUES (?, ?, ?, ?, dateof(now()), ?)");
+                + " (table_name, run_id, run_type, prev_run_id, start_time, status) VALUES (?, ?, ?, ?, totimestamp(now()), ?)");
         boundInitStatement = bindStatement("INSERT INTO " + cdmKsTabDetails
                 + " (table_name, run_id, token_min, token_max, status) VALUES (?, ?, ?, ?, ?)");
         boundEndInfoStatement = bindStatement("UPDATE " + cdmKsTabInfo
-                + " SET end_time = dateof(now()), run_info = ?, status = ? WHERE table_name = ? AND run_id = ?");
+                + " SET end_time = totimestamp(now()), run_info = ?, status = ? WHERE table_name = ? AND run_id = ?");
         boundUpdateStatement = bindStatement("UPDATE " + cdmKsTabDetails
                 + " SET status = ?, run_info = ? WHERE table_name = ? AND run_id = ? AND token_min = ?");
         boundUpdateStartStatement = bindStatement("UPDATE " + cdmKsTabDetails
-                + " SET start_time = dateof(now()), status = ? WHERE table_name = ? AND run_id = ? AND token_min = ?");
+                + " SET start_time = totimestamp(now()), status = ? WHERE table_name = ? AND run_id = ? AND token_min = ?");
         boundSelectInfoStatement = bindStatement(
                 "SELECT status FROM " + cdmKsTabInfo + " WHERE table_name = ? AND run_id = ?");
         boundSelectStatement = bindStatement("SELECT token_min, token_max FROM " + cdmKsTabDetails


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What this PR does**: Converts usage of `dateOf()` to `toTimestamps()` as the `start_time` column is of CQL datatype `TIMESTAMP`.

**Which issue(s) this PR fixes**:
Fixes #350 

**Checklist:**
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
