### PR TITLE
Auto-download Astra DB SCB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ SIT/**/output/*
 .settings/*
 src/main/main.iml
 src/test/test.iml
+
+**/.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ spark-submit --properties-file cdm.properties \
 - Fully containerized (Docker and K8s friendly)
 - SSL Support (including custom cipher algorithms)
 - Migrate from any Cassandra `Origin` ([Apache Cassandra®](https://cassandra.apache.org) / [DataStax Enterprise&trade;](https://www.datastax.com/products/datastax-enterprise) / [DataStax Astra DB&trade;](https://www.datastax.com/products/datastax-astra)) to any Cassandra `Target` ([Apache Cassandra®](https://cassandra.apache.org) / [DataStax Enterprise&trade;](https://www.datastax.com/products/datastax-enterprise) / [DataStax Astra DB&trade;](https://www.datastax.com/products/datastax-astra))
+- Automatic download of Secure Connect Bundles for Astra DB using the DevOps API
 - Supports migration/validation from and to [Azure Cosmos Cassandra](https://learn.microsoft.com/en-us/azure/cosmos-db/cassandra)
 - Validate migration accuracy and performance using a smaller randomized data-set
 - Supports adding custom fixed `writetime` and/or `ttl`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## [5.3.0] - 2025-05-05
+- Auto-download Astra DB Secure Connect Bundle (SCB) when connecting to Astra DB.
+
 ## [5.2.3] - 2025-04-15
 - Randomized the pending token-range list returned by the `trackRun` feature (when rerunning a previously incomplete job) for better load distribution across the cluster.
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
 			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<scm>

--- a/src/main/java/com/datastax/cdm/cql/statement/TargetUpsertRunDetailsStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/TargetUpsertRunDetailsStatement.java
@@ -114,12 +114,8 @@ public class TargetUpsertRunDetailsStatement {
 
         final List<PartitionRange> pendingParts = new ArrayList<PartitionRange>();
         // Use an array of statuses for iteration
-        String[] statuses = {
-            TrackRun.RUN_STATUS.NOT_STARTED.toString(),
-            TrackRun.RUN_STATUS.STARTED.toString(),
-            TrackRun.RUN_STATUS.FAIL.toString(),
-            TrackRun.RUN_STATUS.DIFF.toString()
-        };
+        String[] statuses = { TrackRun.RUN_STATUS.NOT_STARTED.toString(), TrackRun.RUN_STATUS.STARTED.toString(),
+                TrackRun.RUN_STATUS.FAIL.toString(), TrackRun.RUN_STATUS.DIFF.toString() };
         for (String status : statuses) {
             pendingParts.addAll(getPartitionsByStatus(prevRunId, status, jobType));
         }

--- a/src/main/java/com/datastax/cdm/data/AstraDevOpsClient.java
+++ b/src/main/java/com/datastax/cdm/data/AstraDevOpsClient.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.cdm.data;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.cdm.properties.IPropertyHelper;
+import com.datastax.cdm.properties.KnownProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Client for interacting with the Astra DevOps API to download secure connect bundles. This client supports downloading
+ * different types of SCBs (default, regional, custom domain).
+ */
+public class AstraDevOpsClient {
+    private static final Logger logger = LoggerFactory.getLogger(AstraDevOpsClient.class.getName());
+    private static final String ASTRA_API_BASE_URL = "https://api.astra.datastax.com";
+    private static final String SCB_API_PATH = "/v2/databases/%s/secureBundleURL";
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
+
+    private final IPropertyHelper propertyHelper;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates a new AstraDevOpsClient instance.
+     *
+     * @param propertyHelper
+     *            The property helper for accessing configuration
+     */
+    public AstraDevOpsClient(IPropertyHelper propertyHelper) {
+        this.propertyHelper = propertyHelper;
+        this.httpClient = HttpClient.newBuilder().connectTimeout(HTTP_TIMEOUT).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Downloads a secure connect bundle for the specified side (ORIGIN or TARGET).
+     *
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The path to the downloaded SCB file, or null if fails
+     *
+     * @throws IOException
+     *             If an error occurs during the download process
+     */
+    public String downloadSecureBundle(PKFactory.Side side) throws IOException {
+        String token = getAstraToken(side);
+        String databaseId = getAstraDatabaseId(side);
+        String scbType = getScbType(side);
+
+        if (token == null || token.isEmpty() || databaseId == null || databaseId.isEmpty()) {
+            logger.warn("Missing required Astra parameters for {} (token or database ID)", side);
+            return null;
+        }
+
+        logger.info("Auto-downloading secure connect bundle for {} database ID: {}, type: {}", side, databaseId,
+                scbType);
+
+        try {
+            String jsonResponse = fetchSecureBundleUrlInfo(token, databaseId, "region".equals(scbType));
+
+            if (jsonResponse == null) {
+                logger.error("Failed to fetch secure bundle URL info for {}", side);
+                return null;
+            }
+
+            String downloadUrl = extractDownloadUrl(jsonResponse, scbType, side);
+
+            if (downloadUrl == null) {
+                logger.error("Could not extract download URL for {} bundle type: {}", side, scbType);
+                return null;
+            }
+
+            return downloadBundleFile(downloadUrl, side);
+
+        } catch (Exception e) {
+            logger.error("Error downloading secure bundle for {}: {}", side, e.getMessage());
+            throw new IOException("Failed to download secure bundle", e);
+        }
+    }
+
+    /**
+     * Gets the Astra token for the specified side.
+     *
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The Astra token
+     */
+    private String getAstraToken(PKFactory.Side side) {
+        String property = PKFactory.Side.ORIGIN.equals(side) ? KnownProperties.ORIGIN_ASTRA_TOKEN
+                : KnownProperties.TARGET_ASTRA_TOKEN;
+
+        return propertyHelper.getAsString(property);
+    }
+
+    /**
+     * Gets the Astra database ID for the specified side.
+     *
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The Astra database ID
+     */
+    private String getAstraDatabaseId(PKFactory.Side side) {
+        String property = PKFactory.Side.ORIGIN.equals(side) ? KnownProperties.ORIGIN_ASTRA_DATABASE_ID
+                : KnownProperties.TARGET_ASTRA_DATABASE_ID;
+
+        return propertyHelper.getAsString(property);
+    }
+
+    /**
+     * Gets the SCB type for the specified side.
+     *
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The SCB type ("default", "region", or "custom")
+     */
+    private String getScbType(PKFactory.Side side) {
+        String property = PKFactory.Side.ORIGIN.equals(side) ? KnownProperties.ORIGIN_ASTRA_SCB_TYPE
+                : KnownProperties.TARGET_ASTRA_SCB_TYPE;
+
+        return propertyHelper.getAsString(property);
+    }
+
+    /**
+     * Gets the region for regional SCBs.
+     *
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The region name
+     */
+    private String getRegion(PKFactory.Side side) {
+        String property = PKFactory.Side.ORIGIN.equals(side) ? KnownProperties.ORIGIN_ASTRA_SCB_REGION
+                : KnownProperties.TARGET_ASTRA_SCB_REGION;
+
+        return propertyHelper.getAsString(property);
+    }
+
+    /**
+     * Gets the custom domain for custom SCBs.
+     *
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The custom domain
+     */
+    private String getCustomDomain(PKFactory.Side side) {
+        String property = PKFactory.Side.ORIGIN.equals(side) ? KnownProperties.ORIGIN_ASTRA_SCB_CUSTOM_DOMAIN
+                : KnownProperties.TARGET_ASTRA_SCB_CUSTOM_DOMAIN;
+
+        return propertyHelper.getAsString(property);
+    }
+
+    /**
+     * Fetches secure bundle URL information from the Astra DevOps API.
+     *
+     * @param token
+     *            The Astra token
+     * @param databaseId
+     *            The database ID
+     * @param fetchAll
+     *            Whether to fetch all regional bundles
+     *
+     * @return The JSON response as a string
+     *
+     * @throws IOException
+     *             If an error occurs during the API call
+     * @throws InterruptedException
+     *             If the API call is interrupted
+     */
+    private String fetchSecureBundleUrlInfo(String token, String databaseId, boolean fetchAll)
+            throws IOException, InterruptedException {
+
+        String apiUrl = ASTRA_API_BASE_URL + String.format(SCB_API_PATH, databaseId);
+
+        if (fetchAll) {
+            apiUrl += "?all=true";
+        }
+
+        HttpRequest request = HttpRequest.newBuilder().uri(URI.create(apiUrl))
+                .header("Authorization", "Bearer " + token).header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.noBody()).timeout(HTTP_TIMEOUT).build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            logger.error("Failed to fetch secure bundle URL. Status code: {}, Response: {}", response.statusCode(),
+                    response.body());
+            return null;
+        }
+
+        return response.body();
+    }
+
+    /**
+     * Extracts the appropriate download URL from the API response based on the SCB type.
+     *
+     * @param jsonResponse
+     *            The JSON response from the API
+     * @param scbType
+     *            The SCB type
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The download URL
+     *
+     * @throws IOException
+     *             If an error occurs parsing the response
+     */
+    private String extractDownloadUrl(String jsonResponse, String scbType, PKFactory.Side side) throws IOException {
+        JsonNode rootNode = objectMapper.readTree(jsonResponse);
+
+        switch (scbType.toLowerCase()) {
+        case "default":
+            // Default bundle URL extraction
+            if (rootNode.has("downloadURL")) {
+                return rootNode.get("downloadURL").asText();
+            }
+            break;
+
+        case "region":
+            // Regional bundle URL extraction
+            String region = getRegion(side);
+            if (region == null || region.isEmpty()) {
+                logger.error("Region is required for SCB type 'region' but was not specified");
+                return null;
+            }
+
+            if (rootNode.has("downloadURLs") && rootNode.get("downloadURLs").isArray()) {
+                for (JsonNode regionNode : rootNode.get("downloadURLs")) {
+                    if (regionNode.has("region") && region.equalsIgnoreCase(regionNode.get("region").asText())
+                            && regionNode.has("downloadURL")) {
+
+                        return regionNode.get("downloadURL").asText();
+                    }
+                }
+                logger.error("Could not find download URL for region: {}", region);
+            }
+            break;
+
+        case "custom":
+            // Custom domain bundle URL extraction
+            String customDomain = getCustomDomain(side);
+            if (customDomain == null || customDomain.isEmpty()) {
+                logger.error("Custom domain is required for SCB type 'custom' but was not specified");
+                return null;
+            }
+
+            if (rootNode.has("customDomainBundles") && rootNode.get("customDomainBundles").isArray()) {
+                for (JsonNode customNode : rootNode.get("customDomainBundles")) {
+                    if (customNode.has("sniDomain")
+                            && customDomain.equalsIgnoreCase(customNode.get("sniDomain").asText())
+                            && customNode.has("downloadURL")) {
+
+                        return customNode.get("downloadURL").asText();
+                    }
+                }
+                logger.error("Could not find download URL for custom domain: {}", customDomain);
+            }
+            break;
+
+        default:
+            logger.error("Unknown SCB type: {}", scbType);
+            break;
+        }
+
+        return null;
+    }
+
+    /**
+     * Downloads the secure bundle file from the specified URL.
+     *
+     * @param downloadUrl
+     *            The URL to download from
+     * @param side
+     *            The side (ORIGIN or TARGET)
+     *
+     * @return The path to the downloaded file
+     *
+     * @throws IOException
+     *             If an error occurs during download
+     * @throws InterruptedException
+     *             If the download is interrupted
+     */
+    private String downloadBundleFile(String downloadUrl, PKFactory.Side side)
+            throws IOException, InterruptedException {
+
+        logger.info("Downloading secure bundle from URL: {}", downloadUrl);
+
+        HttpRequest downloadRequest = HttpRequest.newBuilder().uri(URI.create(downloadUrl)).GET()
+                .timeout(Duration.ofMinutes(2)).build();
+
+        Path tempDir = Files.createTempDirectory("cdm-scb-" + UUID.randomUUID());
+        String fileName = side.toString().toLowerCase() + "-secure-bundle.zip";
+        Path filePath = tempDir.resolve(fileName);
+
+        HttpResponse<InputStream> downloadResponse = httpClient.send(downloadRequest,
+                HttpResponse.BodyHandlers.ofInputStream());
+
+        if (downloadResponse.statusCode() != 200) {
+            throw new IOException("Failed to download secure bundle. Status code: " + downloadResponse.statusCode());
+        }
+
+        try (InputStream in = downloadResponse.body(); FileOutputStream out = new FileOutputStream(filePath.toFile())) {
+
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        }
+
+        // Ensure the file is deleted when the JVM exits
+        filePath.toFile().deleteOnExit();
+
+        logger.info("Secure bundle downloaded successfully to: {}", filePath);
+        return filePath.toString();
+    }
+}

--- a/src/main/java/com/datastax/cdm/properties/KnownProperties.java
+++ b/src/main/java/com/datastax/cdm/properties/KnownProperties.java
@@ -48,6 +48,23 @@ public class KnownProperties {
     public static final String CONNECT_TARGET_USERNAME = "spark.cdm.connect.target.username";
     public static final String CONNECT_TARGET_PASSWORD = "spark.cdm.connect.target.password";
 
+    // ==========================================================================
+    // Astra DevOps API Parameters
+    // ==========================================================================
+    public static final String ORIGIN_ASTRA_TOKEN = "spark.cdm.connect.origin.astra.token";
+    public static final String ORIGIN_ASTRA_DATABASE_ID = "spark.cdm.connect.origin.astra.database.id";
+    public static final String ORIGIN_ASTRA_AUTO_DOWNLOAD_SCB = "spark.cdm.connect.origin.astra.auto.download.scb";
+    public static final String ORIGIN_ASTRA_SCB_TYPE = "spark.cdm.connect.origin.astra.scb.type";
+    public static final String ORIGIN_ASTRA_SCB_REGION = "spark.cdm.connect.origin.astra.scb.region";
+    public static final String ORIGIN_ASTRA_SCB_CUSTOM_DOMAIN = "spark.cdm.connect.origin.astra.scb.custom.domain";
+
+    public static final String TARGET_ASTRA_TOKEN = "spark.cdm.connect.target.astra.token";
+    public static final String TARGET_ASTRA_DATABASE_ID = "spark.cdm.connect.target.astra.database.id";
+    public static final String TARGET_ASTRA_AUTO_DOWNLOAD_SCB = "spark.cdm.connect.target.astra.auto.download.scb";
+    public static final String TARGET_ASTRA_SCB_TYPE = "spark.cdm.connect.target.astra.scb.type";
+    public static final String TARGET_ASTRA_SCB_REGION = "spark.cdm.connect.target.astra.scb.region";
+    public static final String TARGET_ASTRA_SCB_CUSTOM_DOMAIN = "spark.cdm.connect.target.astra.scb.custom.domain";
+
     static {
         types.put(CONNECT_ORIGIN_HOST, PropertyType.STRING);
         defaults.put(CONNECT_ORIGIN_HOST, "localhost");
@@ -68,6 +85,25 @@ public class KnownProperties {
         defaults.put(CONNECT_TARGET_USERNAME, "cassandra");
         types.put(CONNECT_TARGET_PASSWORD, PropertyType.STRING);
         defaults.put(CONNECT_TARGET_PASSWORD, "cassandra");
+
+        // Astra DevOps API parameters
+        types.put(ORIGIN_ASTRA_TOKEN, PropertyType.STRING);
+        types.put(ORIGIN_ASTRA_DATABASE_ID, PropertyType.STRING);
+        types.put(ORIGIN_ASTRA_AUTO_DOWNLOAD_SCB, PropertyType.BOOLEAN);
+        defaults.put(ORIGIN_ASTRA_AUTO_DOWNLOAD_SCB, "false");
+        types.put(ORIGIN_ASTRA_SCB_TYPE, PropertyType.STRING);
+        defaults.put(ORIGIN_ASTRA_SCB_TYPE, "default");
+        types.put(ORIGIN_ASTRA_SCB_REGION, PropertyType.STRING);
+        types.put(ORIGIN_ASTRA_SCB_CUSTOM_DOMAIN, PropertyType.STRING);
+
+        types.put(TARGET_ASTRA_TOKEN, PropertyType.STRING);
+        types.put(TARGET_ASTRA_DATABASE_ID, PropertyType.STRING);
+        types.put(TARGET_ASTRA_AUTO_DOWNLOAD_SCB, PropertyType.BOOLEAN);
+        defaults.put(TARGET_ASTRA_AUTO_DOWNLOAD_SCB, "false");
+        types.put(TARGET_ASTRA_SCB_TYPE, PropertyType.STRING);
+        defaults.put(TARGET_ASTRA_SCB_TYPE, "default");
+        types.put(TARGET_ASTRA_SCB_REGION, PropertyType.STRING);
+        types.put(TARGET_ASTRA_SCB_CUSTOM_DOMAIN, PropertyType.STRING);
     }
 
     // ==========================================================================

--- a/src/resources/cdm-detailed.properties
+++ b/src/resources/cdm-detailed.properties
@@ -59,6 +59,37 @@ spark.cdm.connect.target.username      cassandra
 spark.cdm.connect.target.password      cassandra
 
 #===========================================================================================================
+# Astra DevOps API Parameters for auto-downloading Secure Connect Bundles
+# These parameters enable automatic download of secure connect bundles from the Astra DevOps API
+# This eliminates the need to manually download and specify the SCB path
+#
+#  spark.cdm.connect.origin.astra
+#  spark.cdm.connect.target.astra
+#   .token              : The Astra DevOps API token. Required if auto-download is enabled.
+#   .database.id        : The Astra Database ID. Required if auto-download is enabled.
+#   .auto.download.scb  : Default is false. Set to true to enable auto-download of the SCB.
+#   .scb.type           : Default is 'default'. Can be 'default', 'region', or 'custom'.
+#   .scb.region         : The region name for regional secure bundles. Required when scb.type is 'region'.
+#   .scb.custom.domain  : The custom domain for custom secure bundles. Required when scb.type is 'custom'.
+#-----------------------------------------------------------------------------------------------------------
+
+# Origin Astra DevOps API configuration
+#spark.cdm.connect.origin.astra.token                  your-astra-devops-api-token
+#spark.cdm.connect.origin.astra.database.id            your-astra-database-id
+#spark.cdm.connect.origin.astra.auto.download.scb      false
+#spark.cdm.connect.origin.astra.scb.type               default
+#spark.cdm.connect.origin.astra.scb.region             us-east-1
+#spark.cdm.connect.origin.astra.scb.custom.domain      your-custom-domain.example.com
+
+# Target Astra DevOps API configuration
+#spark.cdm.connect.target.astra.token                  your-astra-devops-api-token
+#spark.cdm.connect.target.astra.database.id            your-astra-database-id
+#spark.cdm.connect.target.astra.auto.download.scb      false
+#spark.cdm.connect.target.astra.scb.type               default
+#spark.cdm.connect.target.astra.scb.region             us-east-1
+#spark.cdm.connect.target.astra.scb.custom.domain      your-custom-domain.example.com
+
+#===========================================================================================================
 # Details about the Origin Schema
 # 
 # Required Parameters:

--- a/src/test/java/com/datastax/cdm/data/AstraDevOpsClientTest.java
+++ b/src/test/java/com/datastax/cdm/data/AstraDevOpsClientTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.cdm.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.datastax.cdm.properties.IPropertyHelper;
+import com.datastax.cdm.properties.KnownProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class AstraDevOpsClientTest {
+
+    @Mock
+    private IPropertyHelper propertyHelper;
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<String> httpResponse;
+
+    private AstraDevOpsClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Create the client with mocked property helper
+        client = new AstraDevOpsClient(propertyHelper);
+
+        // Use reflection to replace httpClient with our mock
+        Field httpClientField = AstraDevOpsClient.class.getDeclaredField("httpClient");
+        httpClientField.setAccessible(true);
+        httpClientField.set(client, httpClient);
+    }
+
+    @Test
+    void testDownloadSecureBundleWithNullToken() throws IOException {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN)).thenReturn(null);
+
+        // Test
+        String result = client.downloadSecureBundle(PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertNull(result);
+        verify(propertyHelper).getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN);
+    }
+
+    @Test
+    void testDownloadSecureBundleWithEmptyToken() throws IOException {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN)).thenReturn("");
+
+        // Test
+        String result = client.downloadSecureBundle(PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertNull(result);
+        verify(propertyHelper).getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN);
+    }
+
+    @Test
+    void testDownloadSecureBundleWithNullDatabaseId() throws IOException {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN)).thenReturn("test-token");
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_DATABASE_ID)).thenReturn(null);
+
+        // Test
+        String result = client.downloadSecureBundle(PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertNull(result);
+        verify(propertyHelper).getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN);
+        verify(propertyHelper).getAsString(KnownProperties.ORIGIN_ASTRA_DATABASE_ID);
+    }
+
+    @Test
+    void testGetAstraToken() throws Exception {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_TOKEN)).thenReturn("test-token");
+
+        // Use reflection to access the private method
+        Method getAstraTokenMethod = AstraDevOpsClient.class.getDeclaredMethod("getAstraToken", PKFactory.Side.class);
+        getAstraTokenMethod.setAccessible(true);
+
+        // Test
+        String token = (String) getAstraTokenMethod.invoke(client, PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertEquals("test-token", token);
+    }
+
+    @Test
+    void testGetAstraDatabaseId() throws Exception {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.TARGET_ASTRA_DATABASE_ID)).thenReturn("test-db-id");
+
+        // Use reflection to access the private method
+        Method getAstraDatabaseIdMethod = AstraDevOpsClient.class.getDeclaredMethod("getAstraDatabaseId", PKFactory.Side.class);
+        getAstraDatabaseIdMethod.setAccessible(true);
+
+        // Test
+        String dbId = (String) getAstraDatabaseIdMethod.invoke(client, PKFactory.Side.TARGET);
+
+        // Verify
+        assertEquals("test-db-id", dbId);
+    }
+
+    @Test
+    void testGetScbType() throws Exception {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_SCB_TYPE)).thenReturn("region");
+
+        // Use reflection to access the private method
+        Method getScbTypeMethod = AstraDevOpsClient.class.getDeclaredMethod("getScbType", PKFactory.Side.class);
+        getScbTypeMethod.setAccessible(true);
+
+        // Test
+        String scbType = (String) getScbTypeMethod.invoke(client, PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertEquals("region", scbType);
+    }
+
+    @Test
+    void testGetRegion() throws Exception {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.TARGET_ASTRA_SCB_REGION)).thenReturn("us-east-1");
+
+        // Use reflection to access the private method
+        Method getRegionMethod = AstraDevOpsClient.class.getDeclaredMethod("getRegion", PKFactory.Side.class);
+        getRegionMethod.setAccessible(true);
+
+        // Test
+        String region = (String) getRegionMethod.invoke(client, PKFactory.Side.TARGET);
+
+        // Verify
+        assertEquals("us-east-1", region);
+    }
+
+    @Test
+    void testGetCustomDomain() throws Exception {
+        // Setup
+        when(propertyHelper.getAsString(KnownProperties.ORIGIN_ASTRA_SCB_CUSTOM_DOMAIN)).thenReturn("custom.domain.com");
+
+        // Use reflection to access the private method
+        Method getCustomDomainMethod = AstraDevOpsClient.class.getDeclaredMethod("getCustomDomain", PKFactory.Side.class);
+        getCustomDomainMethod.setAccessible(true);
+
+        // Test
+        String customDomain = (String) getCustomDomainMethod.invoke(client, PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertEquals("custom.domain.com", customDomain);
+    }
+
+    @Test
+    void testExtractDownloadUrlDefaultType() throws Exception {
+        // Setup
+        String jsonResponse = "{ \"downloadURL\": \"https://example.com/bundle.zip\" }";
+
+        // Use reflection to access the private method
+        Method extractDownloadUrlMethod = AstraDevOpsClient.class.getDeclaredMethod("extractDownloadUrl", String.class,
+                String.class, PKFactory.Side.class);
+        extractDownloadUrlMethod.setAccessible(true);
+
+        // Test
+        String url = (String) extractDownloadUrlMethod.invoke(client, jsonResponse, "default", PKFactory.Side.ORIGIN);
+
+        // Verify
+        assertEquals("https://example.com/bundle.zip", url);
+    }
+
+    // More tests for extractDownloadUrl with different SCB types can be added here
+}

--- a/src/test/java/com/datastax/cdm/job/ConnectionFetcherTest.java
+++ b/src/test/java/com/datastax/cdm/job/ConnectionFetcherTest.java
@@ -16,19 +16,28 @@
 package com.datastax.cdm.job;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
 
 import org.apache.spark.SparkConf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.datastax.cdm.cql.CommonMocks;
+import com.datastax.cdm.data.AstraDevOpsClient;
 import com.datastax.cdm.data.PKFactory;
 import com.datastax.cdm.properties.IPropertyHelper;
 import com.datastax.cdm.properties.KnownProperties;
 
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class ConnectionFetcherTest extends CommonMocks {
 
     @Mock
@@ -36,6 +45,9 @@ public class ConnectionFetcherTest extends CommonMocks {
 
     @Mock
     private SparkConf conf;
+
+    @Mock
+    private AstraDevOpsClient astraClient;
 
     private ConnectionFetcher cf;
 
@@ -45,23 +57,89 @@ public class ConnectionFetcherTest extends CommonMocks {
         commonSetupWithoutDefaultClassVariables();
         MockitoAnnotations.openMocks(this);
 
-        cf = new ConnectionFetcher(propertyHelper);
+        cf = new ConnectionFetcher(propertyHelper, null);
+
+        // Default values for all tests
+        when(propertyHelper.getAsString(KnownProperties.CONNECT_ORIGIN_HOST)).thenReturn("origin_host");
+        when(propertyHelper.getAsString(KnownProperties.CONNECT_TARGET_HOST)).thenReturn("target_host");
+
+        // Default - auto-download disabled for both ORIGIN and TARGET
+        when(propertyHelper.getBoolean(KnownProperties.ORIGIN_ASTRA_AUTO_DOWNLOAD_SCB)).thenReturn(false);
+        when(propertyHelper.getBoolean(KnownProperties.TARGET_ASTRA_AUTO_DOWNLOAD_SCB)).thenReturn(false);
     }
 
     @Test
     public void getConnectionDetailsOrigin() {
-        when(propertyHelper.getAsString(KnownProperties.CONNECT_ORIGIN_HOST)).thenReturn("origin_host");
-        when(propertyHelper.getAsString(KnownProperties.CONNECT_TARGET_HOST)).thenReturn("target_host");
         ConnectionDetails cd = cf.getConnectionDetails(PKFactory.Side.ORIGIN);
         assertEquals("origin_host", cd.host());
     }
 
     @Test
     public void getConnectionDetailsTarget() {
-        when(propertyHelper.getAsString(KnownProperties.CONNECT_ORIGIN_HOST)).thenReturn("origin_host");
-        when(propertyHelper.getAsString(KnownProperties.CONNECT_TARGET_HOST)).thenReturn("target_host");
         ConnectionDetails cd = cf.getConnectionDetails(PKFactory.Side.TARGET);
         assertEquals("target_host", cd.host());
     }
 
+    @Test
+    public void getConnectionDetailsOriginWithAutoDownloadDisabled() throws Exception {
+        // Create ConnectionFetcher with mocked AstraDevOpsClient
+        cf = new ConnectionFetcher(propertyHelper, astraClient);
+
+        // Test
+        cf.getConnectionDetails(PKFactory.Side.ORIGIN);
+
+        // Verify auto-download was not triggered
+        verify(astraClient, never()).downloadSecureBundle(any());
+    }
+
+    @Test
+    public void getConnectionDetailsOriginWithAutoDownloadEnabled() throws Exception {
+        // Setup
+        when(propertyHelper.getBoolean(KnownProperties.ORIGIN_ASTRA_AUTO_DOWNLOAD_SCB)).thenReturn(true);
+        when(astraClient.downloadSecureBundle(PKFactory.Side.ORIGIN)).thenReturn("/path/to/downloaded/bundle.zip");
+
+        // Create ConnectionFetcher with mocked AstraDevOpsClient
+        cf = new ConnectionFetcher(propertyHelper, astraClient);
+
+        // Test
+        cf.getConnectionDetails(PKFactory.Side.ORIGIN);
+
+        // Verify the SCB path was updated in the property helper
+        verify(propertyHelper).setProperty(KnownProperties.CONNECT_ORIGIN_SCB, "/path/to/downloaded/bundle.zip");
+    }
+
+    @Test
+    public void getConnectionDetailsTargetWithAutoDownloadEnabled() throws Exception {
+        // Setup
+        when(propertyHelper.getBoolean(KnownProperties.TARGET_ASTRA_AUTO_DOWNLOAD_SCB)).thenReturn(true);
+        when(astraClient.downloadSecureBundle(PKFactory.Side.TARGET)).thenReturn("/path/to/downloaded/target-bundle.zip");
+
+        // Create ConnectionFetcher with mocked AstraDevOpsClient
+        cf = new ConnectionFetcher(propertyHelper, astraClient);
+
+        // Test
+        cf.getConnectionDetails(PKFactory.Side.TARGET);
+
+        // Verify the SCB path was updated in the property helper
+        verify(propertyHelper).setProperty(KnownProperties.CONNECT_TARGET_SCB, "/path/to/downloaded/target-bundle.zip");
+    }
+
+    @Test
+    public void getConnectionDetailsWithAutoDownloadFailure() throws Exception {
+        // Setup
+        when(propertyHelper.getBoolean(KnownProperties.ORIGIN_ASTRA_AUTO_DOWNLOAD_SCB)).thenReturn(true);
+        when(astraClient.downloadSecureBundle(PKFactory.Side.ORIGIN)).thenThrow(new RuntimeException("Download failed"));
+
+        // Create ConnectionFetcher with mocked AstraDevOpsClient
+        cf = new ConnectionFetcher(propertyHelper, astraClient);
+
+        // Test - should not throw exception
+        ConnectionDetails cd = cf.getConnectionDetails(PKFactory.Side.ORIGIN);
+
+        // Verify we still get the connection details
+        assertEquals("origin_host", cd.host());
+
+        // And no property update happened
+        verify(propertyHelper, never()).setProperty(any(), any());
+    }
 }


### PR DESCRIPTION
**What this PR does**: Adds enhancement to provide just the Astra database ID along with a token to take care of auto-downloading SCBs to connect with the database clusters.

**Which issue(s) this PR fixes**:
Fixes #347

**Checklist:**
- [x] Automated Tests added/updated
- [x] Documentation added/updated
- [x] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)