### PR TITLE
Report how many Partition-Ranges out of the configured `numParts` passed or failed.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## [5.5.0] - 2025-07-07
+- Logged metrics will now report how many Partition-Ranges out of the configured [`numParts`](https://github.com/datastax/cassandra-data-migrator/blob/main/src/resources/cdm-detailed.properties#L230) passed or failed.
+
 ## [5.4.1] - 2025-06-26
 - Bug fix: Fixed auto column mapping bug when `target` table has more columns than `origin`.
 

--- a/SIT/features/01_constant_column/cdm.fixData.assert
+++ b/SIT/features/01_constant_column/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 1
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/01_constant_column/cdm.migrateData.assert
+++ b/SIT/features/01_constant_column/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 3
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/01_constant_column/cdm.validateData.assert
+++ b/SIT/features/01_constant_column/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/02_explode_map/cdm.fixData.assert
+++ b/SIT/features/02_explode_map/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 5
 Valid Record Count: 5
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/02_explode_map/cdm.migrateData.assert
+++ b/SIT/features/02_explode_map/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 12
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/02_explode_map/cdm.validateData.assert
+++ b/SIT/features/02_explode_map/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 12
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/03_codec/cdm.fixData.assert
+++ b/SIT/features/03_codec/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 1
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/03_codec/cdm.migrateData.assert
+++ b/SIT/features/03_codec/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 3
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/03_codec/cdm.validateData.assert
+++ b/SIT/features/03_codec/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/04_udt_mapper/cdm.fixData.assert
+++ b/SIT/features/04_udt_mapper/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 1
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/04_udt_mapper/cdm.migrateData.assert
+++ b/SIT/features/04_udt_mapper/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 3
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/04_udt_mapper/cdm.validateData.assert
+++ b/SIT/features/04_udt_mapper/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/05_guardrail/cdm.guardrailCheck.assert
+++ b/SIT/features/05_guardrail/cdm.guardrailCheck.assert
@@ -2,3 +2,5 @@ Read Record Count: 4
 Valid Record Count: 1
 Skipped Record Count: 0
 Large Record Count: 3
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/06_constant_column_remove/cdm.fixData.assert
+++ b/SIT/features/06_constant_column_remove/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 1
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/06_constant_column_remove/cdm.migrateData.assert
+++ b/SIT/features/06_constant_column_remove/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 3
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/06_constant_column_remove/cdm.validateData.assert
+++ b/SIT/features/06_constant_column_remove/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/07_constant_column_replace/cdm.fixData.assert
+++ b/SIT/features/07_constant_column_replace/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 1
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/07_constant_column_replace/cdm.migrateData.assert
+++ b/SIT/features/07_constant_column_replace/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 3
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/07_constant_column_replace/cdm.validateData.assert
+++ b/SIT/features/07_constant_column_replace/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/08_map_columns_origin_target/cdm.fixData.assert
+++ b/SIT/features/08_map_columns_origin_target/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 1
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/08_map_columns_origin_target/cdm.migrateData.assert
+++ b/SIT/features/08_map_columns_origin_target/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Write Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/features/08_map_columns_origin_target/cdm.validateData.assert
+++ b/SIT/features/08_map_columns_origin_target/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/01_explode_map_with_constants/cdm.fixData.assert
+++ b/SIT/regression/01_explode_map_with_constants/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 5
 Valid Record Count: 5
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/01_explode_map_with_constants/cdm.migrateData.assert
+++ b/SIT/regression/01_explode_map_with_constants/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 12
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/01_explode_map_with_constants/cdm.validateData.assert
+++ b/SIT/regression/01_explode_map_with_constants/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 12
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/02_ColumnRenameWithConstantsAndExplode/cdm.fixData.assert
+++ b/SIT/regression/02_ColumnRenameWithConstantsAndExplode/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 5
 Valid Record Count: 6
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/02_ColumnRenameWithConstantsAndExplode/cdm.migrateData.assert
+++ b/SIT/regression/02_ColumnRenameWithConstantsAndExplode/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 3
 Skipped Record Count: 0
 Write Record Count: 12
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/02_ColumnRenameWithConstantsAndExplode/cdm.validateData.assert
+++ b/SIT/regression/02_ColumnRenameWithConstantsAndExplode/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 12
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/03_performance/cdm.fixData.assert
+++ b/SIT/regression/03_performance/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 100
 Valid Record Count: 3800
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/03_performance/cdm.migrateData.assert
+++ b/SIT/regression/03_performance/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 4000
 Skipped Record Count: 0
 Write Record Count: 4000
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/regression/03_performance/cdm.validateData.assert
+++ b/SIT/regression/03_performance/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 4000
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/03_ttl_writetime/cdm.fixData.assert
+++ b/SIT/smoke/03_ttl_writetime/cdm.fixData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 3
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/03_ttl_writetime/cdm.migrateData.assert
+++ b/SIT/smoke/03_ttl_writetime/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 8
 Skipped Record Count: 0
 Write Record Count: 8
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/03_ttl_writetime/cdm.validateData.assert
+++ b/SIT/smoke/03_ttl_writetime/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 8
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/04_counters/cdm.fixData.assert
+++ b/SIT/smoke/04_counters/cdm.fixData.assert
@@ -5,3 +5,5 @@ Missing Record Count: 1
 Corrected Missing Record Count: 0
 Valid Record Count: 4
 Skipped Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/04_counters/cdm.fixForce.assert
+++ b/SIT/smoke/04_counters/cdm.fixForce.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 1
 Valid Record Count: 6
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/04_counters/cdm.migrateData.assert
+++ b/SIT/smoke/04_counters/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 7
 Skipped Record Count: 0
 Write Record Count: 7
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/04_counters/cdm.validateData.assert
+++ b/SIT/smoke/04_counters/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 7
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/06_vector/cdm.migrateData.assert
+++ b/SIT/smoke/06_vector/cdm.migrateData.assert
@@ -2,3 +2,5 @@ Read Record Count: 2
 Skipped Record Count: 0
 Write Record Count: 2
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/SIT/smoke/06_vector/cdm.validateData.assert
+++ b/SIT/smoke/06_vector/cdm.validateData.assert
@@ -6,3 +6,5 @@ Corrected Missing Record Count: 0
 Valid Record Count: 2
 Skipped Record Count: 0
 Error Record Count: 0
+Partitions Passed: 1
+Partitions Failed: 0

--- a/src/main/java/com/datastax/cdm/job/CopyJobSession.java
+++ b/src/main/java/com/datastax/cdm/job/CopyJobSession.java
@@ -113,6 +113,7 @@ public class CopyJobSession extends AbstractJobSession<PartitionRange> {
             flushAndClearWrites(batch, writeResults);
             jobCounter.increment(JobCounter.CounterType.WRITE,
                     jobCounter.getCount(JobCounter.CounterType.UNFLUSHED, true));
+            jobCounter.increment(JobCounter.CounterType.PARTITIONS_PASSED);
             jobCounter.reset(JobCounter.CounterType.UNFLUSHED);
             jobCounter.flush();
             if (null != trackRunFeature) {
@@ -123,6 +124,7 @@ public class CopyJobSession extends AbstractJobSession<PartitionRange> {
                     jobCounter.getCount(JobCounter.CounterType.READ, true)
                             - jobCounter.getCount(JobCounter.CounterType.WRITE, true)
                             - jobCounter.getCount(JobCounter.CounterType.SKIPPED, true));
+            jobCounter.increment(JobCounter.CounterType.PARTITIONS_FAILED);
             logger.error("Error with PartitionRange -- ThreadID: {} Processing min: {} max: {}",
                     Thread.currentThread().getId(), min, max, e);
             logger.error("Error stats " + jobCounter.getMetrics(true));

--- a/src/main/java/com/datastax/cdm/job/DiffJobSession.java
+++ b/src/main/java/com/datastax/cdm/job/DiffJobSession.java
@@ -163,23 +163,20 @@ public class DiffJobSession extends CopyJobSession {
                 hasDiff.set(true);
             }
 
+            jobCounter.increment(JobCounter.CounterType.PARTITIONS_PASSED);
+            jobCounter.flush();
             if (hasDiff.get() && null != trackRunFeature) {
                 if (jobCounter.getCount(JobCounter.CounterType.MISSING) == jobCounter
                         .getCount(JobCounter.CounterType.CORRECTED_MISSING)
                         && jobCounter.getCount(JobCounter.CounterType.MISMATCH) == jobCounter
                                 .getCount(JobCounter.CounterType.CORRECTED_MISMATCH)) {
-                    jobCounter.flush();
                     trackRunFeature.updateCdmRun(runId, min, TrackRun.RUN_STATUS.DIFF_CORRECTED,
                             jobCounter.getMetrics());
                 } else {
-                    jobCounter.flush();
                     trackRunFeature.updateCdmRun(runId, min, TrackRun.RUN_STATUS.DIFF, jobCounter.getMetrics());
                 }
             } else if (null != trackRunFeature) {
-                jobCounter.flush();
                 trackRunFeature.updateCdmRun(runId, min, TrackRun.RUN_STATUS.PASS, jobCounter.getMetrics());
-            } else {
-                jobCounter.flush();
             }
         } catch (Exception e) {
             jobCounter.increment(JobCounter.CounterType.ERROR,
@@ -187,6 +184,7 @@ public class DiffJobSession extends CopyJobSession {
                             - jobCounter.getCount(JobCounter.CounterType.MISSING)
                             - jobCounter.getCount(JobCounter.CounterType.MISMATCH)
                             - jobCounter.getCount(JobCounter.CounterType.SKIPPED));
+            jobCounter.increment(JobCounter.CounterType.PARTITIONS_FAILED);
             logger.error("Error with PartitionRange -- ThreadID: {} Processing min: {} max: {}",
                     Thread.currentThread().getId(), min, max, e);
             logger.error("Error stats " + jobCounter.getMetrics(true));

--- a/src/main/java/com/datastax/cdm/job/GuardrailCheckJobSession.java
+++ b/src/main/java/com/datastax/cdm/job/GuardrailCheckJobSession.java
@@ -64,7 +64,9 @@ public class GuardrailCheckJobSession extends AbstractJobSession<PartitionRange>
                     jobCounter.increment(JobCounter.CounterType.VALID);
                 }
             }
+            jobCounter.increment(JobCounter.CounterType.PARTITIONS_PASSED);
         } catch (Exception e) {
+            jobCounter.increment(JobCounter.CounterType.PARTITIONS_FAILED);
             logger.error("Error occurred ", e);
             logger.error("Error with PartitionRange -- ThreadID: {} Processing min: {} max: {}",
                     Thread.currentThread().getId(), min, max);

--- a/src/main/java/com/datastax/cdm/job/JobCounter.java
+++ b/src/main/java/com/datastax/cdm/job/JobCounter.java
@@ -30,7 +30,8 @@ public class JobCounter implements Serializable {
     private static final long serialVersionUID = 7016816604237020549L;
 
     public enum CounterType {
-        READ, WRITE, MISMATCH, CORRECTED_MISMATCH, MISSING, CORRECTED_MISSING, VALID, SKIPPED, LARGE, ERROR, UNFLUSHED
+        READ, WRITE, MISMATCH, CORRECTED_MISMATCH, MISSING, CORRECTED_MISSING, VALID, SKIPPED, LARGE, ERROR, UNFLUSHED,
+        PARTITIONS_PASSED, PARTITIONS_FAILED
     }
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
@@ -40,15 +41,17 @@ public class JobCounter implements Serializable {
         switch (jobType) {
         case MIGRATE:
             setRegisteredTypes(CounterType.READ, CounterType.WRITE, CounterType.SKIPPED, CounterType.ERROR,
-                    CounterType.UNFLUSHED);
+                    CounterType.UNFLUSHED, CounterType.PARTITIONS_PASSED, CounterType.PARTITIONS_FAILED);
             break;
         case VALIDATE:
             setRegisteredTypes(CounterType.READ, CounterType.VALID, CounterType.MISMATCH,
                     CounterType.CORRECTED_MISMATCH, CounterType.MISSING, CounterType.CORRECTED_MISSING,
-                    CounterType.SKIPPED, CounterType.ERROR);
+                    CounterType.SKIPPED, CounterType.ERROR, CounterType.PARTITIONS_PASSED,
+                    CounterType.PARTITIONS_FAILED);
             break;
         case GUARDRAIL:
-            setRegisteredTypes(CounterType.READ, CounterType.VALID, CounterType.SKIPPED, CounterType.LARGE);
+            setRegisteredTypes(CounterType.READ, CounterType.VALID, CounterType.SKIPPED, CounterType.LARGE,
+                    CounterType.PARTITIONS_PASSED, CounterType.PARTITIONS_FAILED);
             break;
         }
     }
@@ -156,8 +159,12 @@ public class JobCounter implements Serializable {
                 if (type == CounterType.UNFLUSHED) {
                     continue;
                 }
-                logger.info("Final " + printFriendlyCase(type.name()) + " Record Count: {}",
-                        counterMap.get(type).getCount());
+                if (type == CounterType.PARTITIONS_PASSED || type == CounterType.PARTITIONS_FAILED) {
+                    logger.info("Final " + printFriendlyCase(type.name()) + ": {}", counterMap.get(type).getCount());
+                } else {
+                    logger.info("Final " + printFriendlyCase(type.name()) + " Record Count: {}",
+                            counterMap.get(type).getCount());
+                }
             }
         }
         logger.info("################################################################################################");

--- a/src/test/java/com/datastax/cdm/job/JobCounterTest.java
+++ b/src/test/java/com/datastax/cdm/job/JobCounterTest.java
@@ -86,12 +86,14 @@ public class JobCounterTest {
     public void printMetricsMigrate() {
         jobCounter = new JobCounter(JobType.MIGRATE);
 
-        String expected = "Read: 10; Write: 7; Skipped: 1; Error: 2";
+        String expected = "Read: 10; Write: 7; Skipped: 1; Error: 2; Partitions Passed: 3; Partitions Failed: 2";
         jobCounter.increment(JobCounter.CounterType.READ, 10);
         jobCounter.increment(JobCounter.CounterType.WRITE, 7);
         jobCounter.increment(JobCounter.CounterType.ERROR, 2);
         jobCounter.increment(JobCounter.CounterType.SKIPPED, 1);
         jobCounter.increment(JobCounter.CounterType.UNFLUSHED, 3);
+        jobCounter.increment(JobCounter.CounterType.PARTITIONS_PASSED, 3);
+        jobCounter.increment(JobCounter.CounterType.PARTITIONS_FAILED, 2);
         jobCounter.flush();
         // You may use mocking to capture logger outputs
         jobCounter.printMetrics(0, trackRun);
@@ -103,11 +105,13 @@ public class JobCounterTest {
     public void printMetricsValidate() {
         jobCounter = new JobCounter(JobType.VALIDATE);
 
-        String expected = "Read: 5; Mismatch: 0; Corrected Mismatch: 0; Missing: 7; Corrected Missing: 7; Valid: 0; Skipped: 0; Error: 72";
+        String expected = "Read: 5; Mismatch: 0; Corrected Mismatch: 0; Missing: 7; Corrected Missing: 7; Valid: 0; Skipped: 0; Error: 72; Partitions Passed: 4; Partitions Failed: 1";
         jobCounter.increment(JobCounter.CounterType.READ, 5);
         jobCounter.increment(JobCounter.CounterType.CORRECTED_MISSING, 7);
         jobCounter.increment(JobCounter.CounterType.ERROR, 72);
         jobCounter.increment(JobCounter.CounterType.MISSING, 7);
+        jobCounter.increment(JobCounter.CounterType.PARTITIONS_PASSED, 4);
+        jobCounter.increment(JobCounter.CounterType.PARTITIONS_FAILED, 1);
         jobCounter.flush();
         // You may use mocking to capture logger outputs
         jobCounter.printMetrics(0, trackRun);


### PR DESCRIPTION
**What this PR does**: Implements feature to report how many Partition-Ranges out of the configured `numParts` passed or failed.

**Which issue(s) this PR fixes**:
Fixes #373 

**Checklist:**
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
