### PR TITLE
Bugfix: Migrate empty text values correctly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [5.5.1] - 2025-08-01
+- Fixed issue related to empty text fields not getting migrated (introduced in 5.4.0). `Null` fields will still be skipped, however not empty strings.
+- Filtered rows will now be logged at LOG4J `TRACE` level to avoid filling the logs. Users can enabled `TRACE` level logging if such logs are needed.
+
 ## [5.5.0] - 2025-07-07
 - Logged metrics will now report how many Partition-Ranges out of the configured [`numParts`](https://github.com/datastax/cassandra-data-migrator/blob/main/src/resources/cdm-detailed.properties#L230) passed or failed.
 

--- a/src/main/java/com/datastax/cdm/cql/statement/OriginSelectStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/OriginSelectStatement.java
@@ -108,8 +108,8 @@ public abstract class OriginSelectStatement extends BaseCdmStatement {
         if (this.filterColumnEnabled) {
             String col = (String) cqlTable.getData(this.filterColumnIndex, record.getOriginRow());
             if (null != col && this.filterColumnString.equalsIgnoreCase(col.trim())) {
-                if (logger.isInfoEnabled())
-                    logger.info("Filter Column removing: {}", record.getPk());
+                if (logger.isTraceEnabled())
+                    logger.trace("Filter Column removing: {}", record.getPk());
                 return true;
             }
         }
@@ -121,8 +121,8 @@ public abstract class OriginSelectStatement extends BaseCdmStatement {
                 return false;
             }
             if (originWriteTimeStamp < minWriteTimeStampFilter || originWriteTimeStamp > maxWriteTimeStampFilter) {
-                if (logger.isInfoEnabled())
-                    logger.info("Timestamp filter removing record with primary key: {} with write timestamp: {}",
+                if (logger.isTraceEnabled())
+                    logger.trace("Timestamp filter removing record with primary key: {} with write timestamp: {}",
                             record.getPk(), originWriteTimeStamp);
                 return true;
             }

--- a/src/main/java/com/datastax/cdm/cql/statement/TargetInsertStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/TargetInsertStatement.java
@@ -79,7 +79,7 @@ public class TargetInsertStatement extends TargetUpsertStatement {
                     bindValue = cqlTable.getOtherCqlTable().getAndConvertData(originIndex, originRow);
                 }
 
-                if (!(null == bindValue || (bindValue instanceof String && ((String) bindValue).isEmpty()))) {
+                if (!(null == bindValue)) {
                     boundStatement = boundStatement.set(currentBindIndex, bindValue,
                             cqlTable.getBindClass(targetIndex));
                 }

--- a/src/main/java/com/datastax/cdm/cql/statement/TargetUpdateStatement.java
+++ b/src/main/java/com/datastax/cdm/cql/statement/TargetUpdateStatement.java
@@ -89,8 +89,7 @@ public class TargetUpdateStatement extends TargetUpsertStatement {
                     bindValueTarget = cqlTable.getOtherCqlTable().getAndConvertData(originIndex, originRow);
                 }
 
-                if (!(null == bindValueTarget
-                        || (bindValueTarget instanceof String && ((String) bindValueTarget).isEmpty()))) {
+                if (!(null == bindValueTarget)) {
                     boundStatement = boundStatement.set(currentBindIndex, bindValueTarget,
                             cqlTable.getBindClass(targetIndex));
                 }


### PR DESCRIPTION
**What this PR does**: Fixes bug related to empty text values. Also changes logging level of filtered rows from INFO to TRACE to avoid filling the logs

**Which issue(s) this PR fixes**:
Fixes #380 

**Checklist:**
- [ ] Automated Tests added/updated
- [ ] Documentation added/updated
- [ ] CLA Signed:  [DataStax CLA](https://cla.datastax.com/)
